### PR TITLE
Make the setup dialog request focus

### DIFF
--- a/src/com/atlauncher/gui/SetupDialog.java
+++ b/src/com/atlauncher/gui/SetupDialog.java
@@ -43,6 +43,7 @@ public class SetupDialog extends JDialog {
 
     public SetupDialog(Settings set) {
         super(null, "ATLauncher Setup", ModalityType.APPLICATION_MODAL);
+        this.requestFocus();
         this.settings = set;
         setSize(400, 200);
         setLocationRelativeTo(null);


### PR DESCRIPTION
Make the setup dialog request focus (Prevents it being hidden behind other windows) (had a problem where I thought it was not opening on my Mac, had to minimise all other windows to find it).
