### PR TITLE
Fixed bug in OS X when try to install MC 1.7+

### DIFF
--- a/src/com/atlauncher/data/mojang/Library.java
+++ b/src/com/atlauncher/data/mojang/Library.java
@@ -29,12 +29,13 @@ public class Library {
         if (this.rules == null) {
             return true; // No rules setup so we need it
         }
+        Action lastAction = Action.DISALLOW;
         for (Rule rule : this.rules) { // Loop through all the rules
             if (rule.ruleApplies()) { // See if this rule applies to this system
-                return (rule.getAction() == Action.ALLOW); // Check if we are allowing it
+                lastAction = rule.getAction();
             }
         }
-        return false;
+        return (lastAction == Action.ALLOW); // Check if we are allowing it
     }
 
     public boolean shouldExtract() {


### PR DESCRIPTION
Majong always checks in there downloader if the last checked rule was successfully. This patch adopts the same to the ATLauncher. In other cases some libs for MC will be installed in two versions and Minecraft crashes.
