### PR TITLE
Catch IOException in loadNews

### DIFF
--- a/src/main/java/com/atlauncher/data/Settings.java
+++ b/src/main/java/com/atlauncher/data/Settings.java
@@ -1454,6 +1454,8 @@ public class Settings {
             logStackTrace(e);
         } catch (UnsupportedEncodingException e) {
             logStackTrace(e);
+        } catch (IOException e) {
+            logStackTrace(e);
         }
         LogManager.debug("Finished loading news");
     }


### PR DESCRIPTION
Pull Request #107 did not handle an IOException when closing a BufferedReader.
