### PR TITLE
Remove duplicate "java" from custom path check

### DIFF
--- a/src/main/java/com/atlauncher/data/Settings.java
+++ b/src/main/java/com/atlauncher/data/Settings.java
@@ -326,7 +326,7 @@ public class Settings {
     }
 
     public void checkForValidJavaPath(boolean save) {
-        File java = new File(App.settings.getJavaPath(), "bin" + File.separator + "java" + File.separator + "java" +
+        File java = new File(App.settings.getJavaPath(), "bin" + File.separator + "java" +
                 (Utils.isWindows() ? ".exe" : ""));
 
         if (!java.exists()) {


### PR DESCRIPTION
This is almost certainly an error, the java binary is at `$JAVAPATH/bin/java`, not `$JAVAPATH/bin/java/java`.