### PR TITLE
Updated readme to reflect changes in LauncherVersion import

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ C:\Program Files (x86)\Launch4j
 To get started with the code and plug in your own data, you need to create a src/main/java/com/atlauncher/data/Constants.java file. Below is a starter to get you going:
 
     package com.atlauncher.data;
+    
+    import com.atlauncher.data.version.LauncherVersion;
 
     public class Constants {
 


### PR DESCRIPTION
Given that in the latest build LauncherVersion is moved from com.atlauncher.data to com.atlauncher.data.version, the template given in the readme for Constants doesn't work unless the new location is imported in

Note: Idk why it tried to pull into master. Apologies for that. Was trying to pull into 3.3.0.0