### PR TITLE
 Log exception tracebacks with printStackTrace instead of by hand

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 !/TESTING.md
 !/CHANGELOG.md
 !/CONTRIBUTING.md
+
+# OS X things
+.DS_Store

--- a/src/main/java/com/atlauncher/ExceptionStrainer.java
+++ b/src/main/java/com/atlauncher/ExceptionStrainer.java
@@ -20,19 +20,17 @@ package com.atlauncher;
 
 import com.atlauncher.managers.LogManager;
 
+import java.io.CharArrayWriter;
+import java.io.PrintWriter;
+
 public final class ExceptionStrainer implements Thread.UncaughtExceptionHandler {
     @Override
     public void uncaughtException(Thread t, Throwable e) {
         e.printStackTrace();
 
-        if (e.getMessage() != null && !e.getMessage().isEmpty()) {
-            LogManager.error(e.getMessage());
-        }
-
-        for (StackTraceElement element : e.getStackTrace()) {
-            if (element != null) {
-                LogManager.error(element.toString());
-            }
+        try (CharArrayWriter writer = new CharArrayWriter()) {
+            e.printStackTrace(new PrintWriter(writer));
+            LogManager.error(writer.toString());
         }
     }
 }

--- a/src/main/java/com/atlauncher/managers/LogManager.java
+++ b/src/main/java/com/atlauncher/managers/LogManager.java
@@ -22,6 +22,8 @@ import com.atlauncher.evnt.LogEvent;
 import com.atlauncher.evnt.LogEvent.LogType;
 import com.atlauncher.thread.LoggingThread;
 
+import java.io.CharArrayWriter;
+import java.io.PrintWriter;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 
@@ -78,25 +80,12 @@ public final class LogManager {
         queue.offer(new LogEvent((LogType) value[0], (String) value[1], 10));
     }
 
-    public static void logStackTrace(Exception exception) {
-        exception.printStackTrace(System.err);
-
-        if (exception.getMessage() != null) {
-            LogManager.error(exception.getMessage());
-        }
-
-        for (StackTraceElement element : exception.getStackTrace()) {
-            if (element != null) {
-                LogManager.error(element.toString());
-            }
-        }
-    }
-
     public static void logStackTrace(Throwable t) {
-        t.printStackTrace(System.err);
-        LogManager.error(t.getMessage());
-        for (StackTraceElement e : t.getStackTrace()) {
-            LogManager.error(e.toString());
+        t.printStackTrace();
+
+        try (CharArrayWriter writer = new CharArrayWriter()) {
+            t.printStackTrace(new PrintWriter(writer));
+            LogManager.error(writer.toString());
         }
     }
 


### PR DESCRIPTION
This makes tracebacks in the launcher log show in the same format that you'd get in a normal Java traceback, including the exception type, the cause (if any), etc. These were previously missing.