### PR TITLE
Make Java version parsing and checking future-proof

### DIFF
--- a/src/main/java/com/atlauncher/Loader.java
+++ b/src/main/java/com/atlauncher/Loader.java
@@ -304,7 +304,7 @@ public class Loader {
             Properties props = new Properties();
             props.load(new FileInputStream(config.toFile()));
 
-            props.setProperty("java_version", OS.getJavaVersion());
+            props.setProperty("java_version", OS.getLauncherJavaVersion());
             props.setProperty("location", FileSystem.BASE_DIR.toString());
             props.setProperty("executable", new File(Update.class.getProtectionDomain().getCodeSource().getLocation()
                     .getPath()).getAbsolutePath());

--- a/src/main/java/com/atlauncher/data/OS.java
+++ b/src/main/java/com/atlauncher/data/OS.java
@@ -26,7 +26,6 @@ import java.awt.datatransfer.StringSelection;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.lang.management.ManagementFactory;
 import java.lang.management.OperatingSystemMXBean;
@@ -158,15 +157,6 @@ public enum OS {
     }
 
     /**
-     * Gets the java version.
-     *
-     * @return the java version
-     */
-    public static String getJavaVersion() {
-        return System.getProperty("java.runtime.version");
-    }
-
-    /**
      * Checks if is 64 bit.
      *
      * @return true, if is 64 bit
@@ -174,10 +164,10 @@ public enum OS {
     public static boolean is64Bit() {
         return System.getProperty("sun.arch.data.model").contains("64");
     }
-    
+
     /**
      * Checks if Windows is 64 bit
-     * 
+     *
      * @return true, if it is 64 bit
      */
     public static boolean isWindows64Bit(){
@@ -312,53 +302,98 @@ public enum OS {
     }
 
     /**
-     * Gets the actual java version.
+     * Get the Java version that the launcher runs on.
      *
-     * @return the actual java version
+     * @return the Java version that the launcher runs on
      */
-    public static String getActualJavaVersion() {
+    public static String getLauncherJavaVersion() {
+        return System.getProperty("java.version");
+    }
+
+    /**
+     * Get the Java version used to run Minecraft.
+     *
+     * @return the Java version used to run Minecraft
+     */
+    public static String getMinecraftJavaVersion() {
         if (SettingsManager.isUsingCustomJavaPath()) {
             File folder = new File(SettingsManager.getJavaPath(), "bin/");
-            List<String> arguments = new ArrayList<String>();
-            arguments.add(folder + File.separator + "java" + (isWindows() ? ".exe" : ""));
-            arguments.add("-version");
-            ProcessBuilder processBuilder = new ProcessBuilder(arguments);
+            String javaCommand = folder + File.separator + "java" + (isWindows() ? ".exe" : "");
+
+            ProcessBuilder processBuilder = new ProcessBuilder(javaCommand, "-version");
             processBuilder.directory(folder);
             processBuilder.redirectErrorStream(true);
+
             String version = "Unknown";
-            BufferedReader br = null;
+
             try {
                 Process process = processBuilder.start();
-                InputStream is = process.getInputStream();
-                InputStreamReader isr = new InputStreamReader(is);
-                br = new BufferedReader(isr);
-                String line = null;
-                Pattern p = Pattern.compile("build ([0-9.-_a-zA-Z]+)");
-                while ((line = br.readLine()) != null) {
-                    // Extract version information
-                    Matcher m = p.matcher(line);
+                try (BufferedReader br = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+                    String line = null;
+                    Pattern p = Pattern.compile("java version \"([^\"]*)\"");
 
-                    if (m.find()) {
-                        version = m.group(1);
-                        break;
+                    while ((line = br.readLine()) != null) {
+                        // Extract version information
+                        Matcher m = p.matcher(line);
+
+                        if (m.find()) {
+                            version = m.group(1);
+                            break;
+                        }
                     }
                 }
             } catch (IOException e) {
                 LogManager.logStackTrace(e);
-            } finally {
-                if (br != null) {
-                    try {
-                        br.close();
-                    } catch (IOException e) {
-                        LogManager.logStackTrace("Cannot close process input stream reader", e);
-                    }
-                }
             }
-            return "Launcher: " + System.getProperty("java.version") + ", Minecraft: " + version;
+
+            LogManager.warn("Cannot get Java version from the ouput of \"" + javaCommand + "\" -version");
+
+            return version;
         } else {
-            return "Launcher: " + System.getProperty("java.version") + ", Minecraft: " + System.getProperty("java" +
-                    ".version");
+            return getLauncherJavaVersion();
         }
+    }
+
+    /**
+     * Parse a Java version string and get the major version number. For example "1.8.0_91" is parsed to 8.
+     *
+     * @param version the version string to parse
+     * @return the parsed major version number
+     */
+    public static int parseJavaVersionNumber(String version) {
+        Matcher m = Pattern.compile("(?:1\\.)?([0-9]+).*").matcher(version);
+
+        return m.find() ? Integer.parseInt(m.group(1)) : -1;
+    }
+
+    /**
+     * Get the major Java version that the launcher runs on.
+     *
+     * @return the major Java version that the launcher runs on
+     */
+    public static int getLauncherJavaVersionNumber() {
+        return parseJavaVersionNumber(getLauncherJavaVersion());
+    }
+
+    /**
+     * Get the major Java version used to run Minecraft.
+     *
+     * @return the major Java version used to run Minecraft
+     */
+    public static int getMinecraftJavaVersionNumber() {
+        return parseJavaVersionNumber(getMinecraftJavaVersion());
+    }
+
+    /**
+     * Get the Java versions used by the Launcher and Minecraft as a string.
+     *
+     * @return the Java versions used by the Launcher and Minecraft as a string
+     */
+    public static String getActualJavaVersion() {
+        return String.format("Launcher: Java %d (%s), Minecraft: Java %d (%s)",
+            getLauncherJavaVersionNumber(), getLauncherJavaVersion(),
+            getMinecraftJavaVersionNumber(), getMinecraftJavaVersion()
+        );
     }
 
     public static boolean isValidJavaPath(String path) {
@@ -366,134 +401,40 @@ public enum OS {
     }
 
     /**
-     * Checks if the user is using Java 7 or above
+     * Checks if the user is using Java 7 or above.
      *
      * @return true if the user is using Java 7 or above else false
      */
     public static boolean isJava7OrAbove(boolean checkCustomPath) {
-        if (SettingsManager.isUsingCustomJavaPath() && checkCustomPath) {
-            File folder = new File(SettingsManager.getJavaPath(), "bin/");
-            List<String> arguments = new ArrayList<String>();
-            arguments.add(folder + File.separator + "java" + (isWindows() ? ".exe" : ""));
-            arguments.add("-version");
-            ProcessBuilder processBuilder = new ProcessBuilder(arguments);
-            processBuilder.directory(folder);
-            processBuilder.redirectErrorStream(true);
-            BufferedReader br = null;
-            int version = -1;
-            try {
-                Process process = processBuilder.start();
-                InputStream is = process.getInputStream();
-                InputStreamReader isr = new InputStreamReader(is);
-                br = new BufferedReader(isr);
-                String line = null;
-                while ((line = br.readLine()) != null) {
-                    if (line.contains("build 1.")) {
-                        int buildIndex = line.indexOf("build 1.") + 8;
-                        version = Integer.parseInt(line.substring(buildIndex, buildIndex + 1));
-                        break;
-                    }
-                }
-                if (version == -1) {
-                    LogManager.warn("Cannot get java version number from the ouput of java -version");
-                } else {
-                    return version >= 7;
-                }
-            } catch (NumberFormatException e) {
-                LogManager.logStackTrace("Cannot get number from the ouput of java -version", e);
-            } catch (IOException e) {
-                LogManager.logStackTrace(e);
-            } finally {
-                if (br != null) {
-                    try {
-                        br.close();
-                    } catch (IOException e) {
-                        LogManager.logStackTrace("Cannot close input stream reader", e);
-                    }
-                }
-            }
-            return true; // Can't determine version, so assume true.
-        } else {
-            return Integer.parseInt(System.getProperty("java.version").substring(2, 3)) >= 7;
-        }
+        int version = checkCustomPath ? getMinecraftJavaVersionNumber() : getLauncherJavaVersionNumber();
+        return version >= 7 || version == -1;
     }
 
     /**
-     * Checks if is java8.
+     * Checks if the user is using exactly Java 8.
      *
-     * @return true, if is java8
+     * @return true if the user is using exactly Java 8
      */
     public static boolean isJava8() {
-        if (SettingsManager.isUsingCustomJavaPath()) {
-            File folder = new File(SettingsManager.getJavaPath(), "bin/");
-            List<String> arguments = new ArrayList<String>();
-            arguments.add(folder + File.separator + "java" + (isWindows() ? ".exe" : ""));
-            arguments.add("-version");
-            ProcessBuilder processBuilder = new ProcessBuilder(arguments);
-            processBuilder.directory(folder);
-            processBuilder.redirectErrorStream(true);
-            BufferedReader br = null;
-            try {
-                Process process = processBuilder.start();
-                InputStream is = process.getInputStream();
-                InputStreamReader isr = new InputStreamReader(is);
-                br = new BufferedReader(isr);
-                String line = br.readLine(); // Read first line only
-                return line.contains("\"1.8");
-            } catch (IOException e) {
-                LogManager.logStackTrace(e);
-            } finally {
-                if (br != null) {
-                    try {
-                        br.close();
-                    } catch (IOException e) {
-                        LogManager.logStackTrace("Cannot close input stream reader", e);
-                    }
-                }
-            }
-            return false; // Can't determine version, so fall back to not being Java 8
-        } else {
-            return System.getProperty("java.version").substring(0, 3).equalsIgnoreCase("1.8");
-        }
+        return getMinecraftJavaVersionNumber() == 8;
     }
 
     /**
-     * Checks if is java9.
+     * Checks if the user is using exactly Java 9.
      *
-     * @return true, if is java9
+     * @return true if the user is using exactly Java 9
      */
     public static boolean isJava9() {
-        if (SettingsManager.isUsingCustomJavaPath()) {
-            File folder = new File(SettingsManager.getJavaPath(), "bin/");
-            List<String> arguments = new ArrayList<String>();
-            arguments.add(folder + File.separator + "java" + (isWindows() ? ".exe" : ""));
-            arguments.add("-version");
-            ProcessBuilder processBuilder = new ProcessBuilder(arguments);
-            processBuilder.directory(folder);
-            processBuilder.redirectErrorStream(true);
-            BufferedReader br = null;
-            try {
-                Process process = processBuilder.start();
-                InputStream is = process.getInputStream();
-                InputStreamReader isr = new InputStreamReader(is);
-                br = new BufferedReader(isr);
-                String line = br.readLine(); // Read first line only
-                return line.contains("\"1.9");
-            } catch (IOException e) {
-                LogManager.logStackTrace(e);
-            } finally {
-                if (br != null) {
-                    try {
-                        br.close();
-                    } catch (IOException e) {
-                        LogManager.logStackTrace("Cannot close input stream reader", e);
-                    }
-                }
-            }
-            return false; // Can't determine version, so fall back to not being Java 8
-        } else {
-            return System.getProperty("java.version").substring(0, 3).equalsIgnoreCase("1.9");
-        }
+        return getMinecraftJavaVersionNumber() == 9;
+    }
+
+	/**
+     * Checks whether Metaspace should be used instead of PermGen. This is the case for Java 8 and above.
+     *
+     * @return whether Metaspace should be used instead of PermGen
+     */
+    public static boolean useMetaspace() {
+        return getMinecraftJavaVersionNumber() >= 8;
     }
 
     public static String getMACAdressHash() {

--- a/src/main/java/com/atlauncher/mclauncher/LegacyMCLauncher.java
+++ b/src/main/java/com/atlauncher/mclauncher/LegacyMCLauncher.java
@@ -133,13 +133,13 @@ public class LegacyMCLauncher {
             arguments.add("-Xmx" + SettingsManager.getMaximumMemory() + "M");
         }
         if (SettingsManager.getPermGen() < instance.getPermGen() && (OS.getMaximumRam() / 8) < instance.getPermGen()) {
-            if (OS.isJava8()) {
+            if (OS.useMetaspace()) {
                 arguments.add("-XX:MetaspaceSize=" + instance.getPermGen() + "M");
             } else {
                 arguments.add("-XX:PermSize=" + instance.getPermGen() + "M");
             }
         } else {
-            if (OS.isJava8()) {
+            if (OS.useMetaspace()) {
                 arguments.add("-XX:MetaspaceSize=" + SettingsManager.getPermGen() + "M");
             } else {
                 arguments.add("-XX:PermSize=" + SettingsManager.getPermGen() + "M");

--- a/src/main/java/com/atlauncher/mclauncher/MCLauncher.java
+++ b/src/main/java/com/atlauncher/mclauncher/MCLauncher.java
@@ -135,13 +135,13 @@ public class MCLauncher {
         }
         if (SettingsManager.getPermGen() < instance.getPermGen() && (OS.getMaximumRam() / 8) < instance.getPermGen
                 ()) {
-            if (OS.isJava8() || OS.isJava9()) {
+            if (OS.useMetaspace()) {
                 arguments.add("-XX:MetaspaceSize=" + instance.getPermGen() + "M");
             } else {
                 arguments.add("-XX:PermSize=" + instance.getPermGen() + "M");
             }
         } else {
-            if (OS.isJava8() || OS.isJava9()) {
+            if (OS.useMetaspace()) {
                 arguments.add("-XX:MetaspaceSize=" + SettingsManager.getPermGen() + "M");
             } else {
                 arguments.add("-XX:PermSize=" + SettingsManager.getPermGen() + "M");


### PR DESCRIPTION
* Fixed Java version parsing to work with Java 9 (and hopefully future
versions)
* Separated Java version getting, parsing and checking
* New methods to get the launcher or Minecraft Java version as a string
or int
* New method to check whether Metaspace should be used instead of
PermGen when launching Minecraft (so manual checking for each Java
version isn't necessary)

Fixes #262.

If you want to test, the log now also shows what each version number is parsed to:

```
Java Version: Launcher: Java 8 (1.8.0_92), Minecraft: Java 8 (1.8.0_92)
```

This means that the version string is `1.8.0_92` and the launcher parses it as Java version 8.

(Also I assume the launcher has no external API that has to be kept stable? I simply removed `OS.getJavaVersion` when I added  `OS.getLauncherJavaVersion` and `OS.getMinecraftJavaVersion` so there's no confusion about which version it gets.)