### PR TITLE
#279: fixed wrong font width length

### DIFF
--- a/src/main/java/com/atlauncher/gui/dialogs/InstanceInstallerDialog.java
+++ b/src/main/java/com/atlauncher/gui/dialogs/InstanceInstallerDialog.java
@@ -189,7 +189,7 @@ public class InstanceInstallerDialog extends JDialog {
 
         // ensures that font width is taken into account
         for (PackVersion version : versions) {
-            versionLength = Math.max(versionLength, getFontMetrics(Utils.getFont()).stringWidth(version.toString()) + 254);
+            versionLength = Math.max(versionLength, getFontMetrics(Utils.getFont()).stringWidth(version.toString()) + 25);
         }
 
         // ensures that the dropdown is at least 200 px wide


### PR DESCRIPTION
@RyanTheAllmighty for whatever reason the added buffer in `versionLength = Math.max(versionLength, getFontMetrics(Utils.getFont()).stringWidth(version.toString()) + 25);` was instead set to 254 instead of 25, so I fixed that. Sorry about needing to merge again