### PR TITLE
Exception logging improvements and other fixes

### DIFF
--- a/src/main/java/com/atlauncher/App.java
+++ b/src/main/java/com/atlauncher/App.java
@@ -298,7 +298,7 @@ public class App {
                 // Try to enable the tray icon.
                 trySystemTrayIntegration();
             } catch (Exception e) {
-                settings.logStackTrace(e);
+                LogManager.logStackTrace(e);
             }
         }
 

--- a/src/main/java/com/atlauncher/App.java
+++ b/src/main/java/com/atlauncher/App.java
@@ -17,6 +17,38 @@
  */
 package com.atlauncher;
 
+import java.awt.Dimension;
+import java.awt.Image;
+import java.awt.SystemTray;
+import java.awt.TrayIcon;
+import java.awt.event.KeyEvent;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.lang.reflect.Method;
+import java.util.Enumeration;
+import java.util.Locale;
+import java.util.Properties;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+import javax.swing.InputMap;
+import javax.swing.JOptionPane;
+import javax.swing.KeyStroke;
+import javax.swing.SwingUtilities;
+import javax.swing.ToolTipManager;
+import javax.swing.UIManager;
+import javax.swing.text.DefaultEditorKit;
+
 import com.atlauncher.data.Constants;
 import com.atlauncher.data.Instance;
 import com.atlauncher.data.Pack;
@@ -28,36 +60,8 @@ import com.atlauncher.gui.dialogs.SetupDialog;
 import com.atlauncher.gui.theme.Theme;
 import com.atlauncher.utils.HTMLUtils;
 import com.atlauncher.utils.Utils;
-import io.github.asyncronous.toast.Toaster;
 
-import javax.swing.InputMap;
-import javax.swing.JOptionPane;
-import javax.swing.KeyStroke;
-import javax.swing.SwingUtilities;
-import javax.swing.ToolTipManager;
-import javax.swing.UIManager;
-import javax.swing.text.DefaultEditorKit;
-import java.awt.Dimension;
-import java.awt.Image;
-import java.awt.SystemTray;
-import java.awt.TrayIcon;
-import java.awt.event.KeyEvent;
-import java.awt.event.MouseAdapter;
-import java.awt.event.MouseEvent;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.lang.reflect.Method;
-import java.util.Enumeration;
-import java.util.Locale;
-import java.util.Properties;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipFile;
+import io.github.asyncronous.toast.Toaster;
 
 /**
  * Main entry point for the application, Java runs the main method here when the application is launched.
@@ -332,15 +336,13 @@ public class App {
             System.setProperty("com.apple.mrj.application.apple.menu.about.name", Constants.LAUNCHER_NAME + " " +
                 Constants.VERSION);
             try {
-                Class util = Class.forName("com.apple.eawt.Application");
-                Method getApplication = util.getMethod("getApplication", new Class[0]);
+                Class<?> util = Class.forName("com.apple.eawt.Application");
+                Method getApplication = util.getMethod("getApplication");
                 Object application = getApplication.invoke(util);
-                Class params[] = new Class[1];
-                params[0] = Image.class;
-                Method setDockIconImage = util.getMethod("setDockIconImage", params);
+                Method setDockIconImage = util.getMethod("setDockIconImage", Image.class);
                 setDockIconImage.invoke(application, Utils.getImage("/assets/image/Icon.png"));
             } catch (Exception ex) {
-                ex.printStackTrace(System.err);
+                LogManager.logStackTrace("Failed to set dock icon", ex);
             }
         }
 
@@ -498,37 +500,74 @@ public class App {
      * about itself and it's location in a set location.
      */
     public static void integrate() {
+        if (!Utils.getOSStorageDir().exists()) {
+            boolean success = Utils.getOSStorageDir().mkdirs();
+            if (!success) {
+                LogManager.error("Failed to create OS storage directory");
+                return;
+            }
+        }
+
+        File f = new File(Utils.getOSStorageDir(), "atlauncher.conf");
+
         try {
-            if (!Utils.getOSStorageDir().exists()) {
-                Utils.getOSStorageDir().mkdirs();
-            }
-
-            File f = new File(Utils.getOSStorageDir(), "atlauncher.conf");
-
-            if (!f.exists()) {
-                f.createNewFile();
-            }
-
-            Properties props = new Properties();
-            props.load(new FileInputStream(f));
-
-            props.setProperty("java_version", Utils.getLauncherJavaVersion());
-            props.setProperty("location", App.settings.getBaseDir().toString());
-            props.setProperty("executable", new File(Update.class.getProtectionDomain().getCodeSource().getLocation()
-                .getPath()).getAbsolutePath());
-
-            packCodeToAdd = props.getProperty("pack_code_to_add", null);
-            props.remove("pack_code_to_add");
-
-            packToInstall = props.getProperty("pack_to_install", null);
-            props.remove("pack_to_install");
-
-            packShareCodeToInstall = props.getProperty("pack_share_code_to_install", null);
-            props.remove("pack_share_code_to_install");
-
-            props.store(new FileOutputStream(f), "");
+            f.createNewFile();
         } catch (IOException e) {
-            e.printStackTrace();
+            LogManager.logStackTrace("Failed to create atlauncher.conf", e);
+            return;
+        }
+
+        Properties props = new Properties();
+        InputStream is = null;
+        try {
+            is = new FileInputStream(f);
+            props.load(is);
+        } catch (FileNotFoundException e) {
+            LogManager.logStackTrace("Failed to open atlauncher.conf for reading", e);
+            return;
+        } catch (IOException e) {
+            LogManager.logStackTrace("Failed to read from atlauncher.conf", e);
+            return;
+        } finally {
+            if (is != null) {
+                try {
+                    is.close();
+                } catch (IOException e) {
+                    LogManager.logStackTrace("Failed to close atlauncher.conf FileInputStream", e);
+                }
+            }
+        }
+
+        props.setProperty("java_version", Utils.getLauncherJavaVersion());
+        props.setProperty("location", App.settings.getBaseDir().toString());
+        props.setProperty("executable", new File(Update.class.getProtectionDomain().getCodeSource().getLocation()
+            .getPath()).getAbsolutePath());
+
+        packCodeToAdd = props.getProperty("pack_code_to_add", null);
+        props.remove("pack_code_to_add");
+
+        packToInstall = props.getProperty("pack_to_install", null);
+        props.remove("pack_to_install");
+
+        packShareCodeToInstall = props.getProperty("pack_share_code_to_install", null);
+        props.remove("pack_share_code_to_install");
+
+        OutputStream os = null;
+        try {
+            os = new FileOutputStream(f);
+            props.store(os, "");
+        } catch (FileNotFoundException e) {
+            LogManager.logStackTrace("Failed to open atlauncher.conf for writing", e);
+        } catch (IOException e) {
+            LogManager.logStackTrace("Failed to write to atlauncher.conf", e);
+        } finally {
+            if (os != null) {
+                try {
+                    os.close();
+                } catch (IOException e) {
+                    LogManager.logStackTrace("Failed to close atlauncher.conf FileOutputStream", e);
+                }
+            }
         }
     }
 }

--- a/src/main/java/com/atlauncher/ExceptionStrainer.java
+++ b/src/main/java/com/atlauncher/ExceptionStrainer.java
@@ -18,20 +18,9 @@
 
 package com.atlauncher;
 
-import java.io.CharArrayWriter;
-import java.io.PrintWriter;
-
 public final class ExceptionStrainer implements Thread.UncaughtExceptionHandler {
     @Override
     public void uncaughtException(Thread t, Throwable e) {
-        e.printStackTrace();
-    
-        CharArrayWriter writer = new CharArrayWriter();
-        try {
-            e.printStackTrace(new PrintWriter(writer));
-            LogManager.error(writer.toString());
-        } finally {
-            writer.close();
-        }
+        LogManager.logStackTrace(e);
     }
 }

--- a/src/main/java/com/atlauncher/LogManager.java
+++ b/src/main/java/com/atlauncher/LogManager.java
@@ -23,6 +23,8 @@ import com.atlauncher.evnt.LogEvent.LogType;
 import com.atlauncher.thread.LoggingThread;
 import com.atlauncher.utils.Utils;
 
+import java.io.CharArrayWriter;
+import java.io.PrintWriter;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 
@@ -74,5 +76,33 @@ public final class LogManager {
     public static void minecraft(String message) {
         Object[] value = Utils.prepareMessageForMinecraftLog(message);
         queue.offer(new LogEvent((LogType) value[0], (String) value[1], 10));
+    }
+    
+    /**
+     * Logs a stack trace to the console window
+     *
+     * @param t The throwable to show in the console
+     */
+    public static void logStackTrace(Throwable t) {
+        t.printStackTrace();
+
+        CharArrayWriter writer = new CharArrayWriter();
+        try {
+            t.printStackTrace(new PrintWriter(writer));
+            error(writer.toString());
+        } finally {
+            writer.close();
+        }
+    }
+    
+    /**
+     * Logs a stack trace to the console window with a custom message before it
+     *
+     * @param message   A message regarding the stack trace to show before it providing more insight
+     * @param t The throwable to show in the console
+     */
+    public static void logStackTrace(String message, Throwable t) {
+        error(message);
+        logStackTrace(t);
     }
 }

--- a/src/main/java/com/atlauncher/data/Account.java
+++ b/src/main/java/com/atlauncher/data/Account.java
@@ -192,7 +192,7 @@ public class Account implements Serializable {
         try {
             image = ImageIO.read(file);
         } catch (IOException e) {
-            App.settings.logStackTrace(e);
+            LogManager.logStackTrace(e);
         }
 
         BufferedImage main = image.getSubimage(8, 8, 8, 8);
@@ -231,7 +231,7 @@ public class Account implements Serializable {
         try {
             image = ImageIO.read(file);
         } catch (IOException e) {
-            App.settings.logStackTrace(e);
+            LogManager.logStackTrace(e);
         }
 
         BufferedImage head = image.getSubimage(8, 8, 8, 8);
@@ -474,9 +474,9 @@ public class Account implements Serializable {
                                 }
                             }
                         } catch (MalformedURLException e) {
-                            App.settings.logStackTrace(e);
+                            LogManager.logStackTrace(e);
                         } catch (IOException e) {
-                            App.settings.logStackTrace(e);
+                            LogManager.logStackTrace(e);
                         }
                         App.settings.reloadAccounts();
                     }
@@ -526,7 +526,7 @@ public class Account implements Serializable {
             }
             reader.close();
         } catch (IOException e) {
-            App.settings.logStackTrace(e);
+            LogManager.logStackTrace(e);
             response = null;
         }
 

--- a/src/main/java/com/atlauncher/data/DisableableMod.java
+++ b/src/main/java/com/atlauncher/data/DisableableMod.java
@@ -144,7 +144,7 @@ public class DisableableMod implements Serializable {
                             inputFile.delete();
                             outputTmpFile.renameTo(inputFile);
                         } catch (IOException e) {
-                            App.settings.logStackTrace(e);
+                            LogManager.logStackTrace(e);
                         }
                     }
                 }

--- a/src/main/java/com/atlauncher/data/Downloadable.java
+++ b/src/main/java/com/atlauncher/data/Downloadable.java
@@ -187,7 +187,7 @@ public class Downloadable {
             try {
                 this.hash = getHashFromURL();
             } catch (IOException e) {
-                App.settings.logStackTrace(e);
+                LogManager.logStackTrace(e);
                 this.hash = "-";
                 this.connection = null;
             }
@@ -271,7 +271,7 @@ public class Downloadable {
                 LogManager.debug("Connection opened to " + this.url, 3);
             } catch (IOException e) {
                 LogManager.debug("Exception when opening connection to " + this.url, 3);
-                App.settings.logStackTrace(e);
+                LogManager.logStackTrace(e);
                 if (this.isATLauncherDownload) {
                     if (getNextServer()) {
                         this.url = server.getFileURL(this.beforeURL);
@@ -317,7 +317,7 @@ public class Downloadable {
         } catch (SocketException e) {
             LogManager.error("Failed to download " + this.url + " due to SocketException!");
             // Connection reset. Close connection and try again
-            App.settings.logStackTrace(e);
+            LogManager.logStackTrace(e);
             this.connection.disconnect();
             this.connection = null;
             if (this.oldFile != null && this.oldFile.exists()) {
@@ -325,7 +325,7 @@ public class Downloadable {
             }
         } catch (IOException e) {
             LogManager.error("Failed to download " + this.url + " due to IOException!");
-            App.settings.logStackTrace(e);
+            LogManager.logStackTrace(e);
             if (this.oldFile != null && this.oldFile.exists()) {
                 Utils.moveFile(this.oldFile, this.file, true);
             }
@@ -338,7 +338,7 @@ public class Downloadable {
                     in.close();
                 }
             } catch (IOException e1) {
-                App.settings.logStackTrace(e1);
+                LogManager.logStackTrace(e1);
             }
         }
     }
@@ -367,7 +367,7 @@ public class Downloadable {
             in.close();
         } catch (IOException e) {
             LogManager.error("Failed to get contents of " + this.url + " due to IOException!");
-            App.settings.logStackTrace(e);
+            LogManager.logStackTrace(e);
             return null;
         }
         this.connection.disconnect();
@@ -514,7 +514,7 @@ public class Downloadable {
         try {
             return getConnection().getResponseCode();
         } catch (IOException e) {
-            App.settings.logStackTrace("IOException when getting response code for the url " + this.url, e);
+            LogManager.logStackTrace("IOException when getting response code for the url " + this.url, e);
             return -1;
         }
     }

--- a/src/main/java/com/atlauncher/data/DropboxSync.java
+++ b/src/main/java/com/atlauncher/data/DropboxSync.java
@@ -87,7 +87,7 @@ public class DropboxSync extends SyncAbstract {
                     try {
                         bufferedReader.close();
                     } catch (IOException e) {
-                        App.settings.logStackTrace(e);
+                        LogManager.logStackTrace(e);
                     }
                 }
             }

--- a/src/main/java/com/atlauncher/data/Instance.java
+++ b/src/main/java/com/atlauncher/data/Instance.java
@@ -17,6 +17,24 @@
  */
 package com.atlauncher.data;
 
+import java.awt.Image;
+import java.awt.image.BufferedImage;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Writer;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.imageio.ImageIO;
+import javax.swing.ImageIcon;
+import javax.swing.JOptionPane;
+
 import com.atlauncher.App;
 import com.atlauncher.Gsons;
 import com.atlauncher.LogManager;
@@ -26,22 +44,6 @@ import com.atlauncher.mclauncher.LegacyMCLauncher;
 import com.atlauncher.mclauncher.MCLauncher;
 import com.atlauncher.utils.HTMLUtils;
 import com.atlauncher.utils.Utils;
-
-import javax.imageio.ImageIO;
-import javax.swing.ImageIcon;
-import javax.swing.JOptionPane;
-import java.awt.Image;
-import java.awt.image.BufferedImage;
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 /**
  * This class handles contains information about a single Instance in the Launcher. An Instance being an installed
@@ -1426,24 +1428,30 @@ public class Instance implements Cloneable {
     }
 
     public void save(boolean showToast) {
+        Writer writer;
         try {
-            FileWriter writer = null;
-            try {
-                writer = new FileWriter(new File(new File(App.settings.getInstancesDir(), this.getSafeName()),
-                    "instance.json"));
-                writer.write(Gsons.DEFAULT.toJson(this));
-                writer.flush();
+            writer = new FileWriter(new File(new File(App.settings.getInstancesDir(), this.getSafeName()),
+                "instance.json"));
+        } catch (IOException e) {
+            LogManager.logStackTrace("Failed to open instance.json for writing", e);
+            return;
+        }
+        
+        try {
+            writer.write(Gsons.DEFAULT.toJson(this));
+            writer.flush();
 
-                if (showToast) {
-                    App.TOASTER.pop("Instance " + this.getName());
-                }
-            } finally {
-                if (writer != null) {
-                    writer.close();
-                }
+            if (showToast) {
+                App.TOASTER.pop("Instance " + this.getName());
             }
         } catch (IOException e) {
-            e.printStackTrace(System.err);
+            LogManager.logStackTrace("Failed to write instance.json", e);
+        } finally {
+            try {
+                writer.close();
+            } catch (IOException e) {
+                LogManager.logStackTrace("Failed to close instance.json writer", e);
+            }
         }
     }
 

--- a/src/main/java/com/atlauncher/data/Instance.java
+++ b/src/main/java/com/atlauncher/data/Instance.java
@@ -419,7 +419,7 @@ public class Instance implements Cloneable {
                 Image dimg = img.getScaledInstance(300, 150, Image.SCALE_SMOOTH);
                 return new ImageIcon(dimg);
             } catch (IOException e) {
-                App.settings.logStackTrace("Error creating scaled image from the custom image of instance " + this
+                LogManager.logStackTrace("Error creating scaled image from the custom image of instance " + this
                     .getName(), e);
             }
         }
@@ -1307,7 +1307,7 @@ public class Instance implements Cloneable {
                             System.exit(0);
                         }
                     } catch (IOException e1) {
-                        App.settings.logStackTrace(e1);
+                        LogManager.logStackTrace(e1);
                     }
                 }
             };
@@ -1367,7 +1367,7 @@ public class Instance implements Cloneable {
         try {
             return Utils.sendAPICall("pack/" + getRealPack().getSafeName() + "/timeplayed/", request);
         } catch (IOException e) {
-            App.settings.logStackTrace(e);
+            LogManager.logStackTrace(e);
         }
         return "Leaderboard Time Not Added!";
     }

--- a/src/main/java/com/atlauncher/data/Language.java
+++ b/src/main/java/com/atlauncher/data/Language.java
@@ -18,9 +18,6 @@
 
 package com.atlauncher.data;
 
-import com.atlauncher.App;
-import com.atlauncher.LogManager;
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FilenameFilter;
@@ -28,6 +25,9 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+
+import com.atlauncher.App;
+import com.atlauncher.LogManager;
 
 public enum Language {
     INSTANCE, Language;
@@ -38,8 +38,8 @@ public enum Language {
     private Language() {
         try {
             this.load("English");
-        } catch (Exception ex) {
-            ex.printStackTrace(System.err);
+        } catch (IOException ex) {
+            LogManager.logStackTrace("Failed to load language", ex);
         }
     }
 

--- a/src/main/java/com/atlauncher/data/Pack.java
+++ b/src/main/java/com/atlauncher/data/Pack.java
@@ -36,7 +36,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.StringReader;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -335,7 +334,7 @@ public class Pack {
             }
         } catch (Exception e) {
             String result = Utils.uploadPaste(Constants.LAUNCHER_NAME + " Error", xml);
-            App.settings.logStackTrace("Exception when reading a versions XML. See error details at " + result, e);
+            LogManager.logStackTrace("Exception when reading a versions XML. See error details at " + result, e);
         }
         return null;
     }
@@ -359,7 +358,7 @@ public class Pack {
             }
         } catch (Exception e) {
             String result = Utils.uploadPaste(Constants.LAUNCHER_NAME + " Error", xml);
-            App.settings.logStackTrace("Exception when reading a versions XML. See error details at " + result, e);
+            LogManager.logStackTrace("Exception when reading a versions XML. See error details at " + result, e);
         }
         return null;
     }
@@ -383,7 +382,7 @@ public class Pack {
             }
         } catch (Exception e) {
             String result = Utils.uploadPaste(Constants.LAUNCHER_NAME + " Error", xml);
-            App.settings.logStackTrace("Exception when reading a versions XML. See error details at " + result, e);
+            LogManager.logStackTrace("Exception when reading a versions XML. See error details at " + result, e);
         }
         return null;
     }
@@ -407,7 +406,7 @@ public class Pack {
             }
         } catch (Exception e) {
             String result = Utils.uploadPaste(Constants.LAUNCHER_NAME + " Error", xml);
-            App.settings.logStackTrace("Exception when reading a versions XML. See error details at " + result, e);
+            LogManager.logStackTrace("Exception when reading a versions XML. See error details at " + result, e);
         }
         return 0;
     }
@@ -431,7 +430,7 @@ public class Pack {
             }
         } catch (Exception e) {
             String result = Utils.uploadPaste(Constants.LAUNCHER_NAME + " Error", xml);
-            App.settings.logStackTrace("Exception when reading a versions XML. See error details at " + result, e);
+            LogManager.logStackTrace("Exception when reading a versions XML. See error details at " + result, e);
         }
         return null;
     }
@@ -456,7 +455,7 @@ public class Pack {
             }
         } catch (Exception e) {
             String result = Utils.uploadPaste(Constants.LAUNCHER_NAME + " Error", xml);
-            App.settings.logStackTrace("Exception when reading a versions XML. See error details at " + result, e);
+            LogManager.logStackTrace("Exception when reading a versions XML. See error details at " + result, e);
         }
         return null;
     }
@@ -481,7 +480,7 @@ public class Pack {
             }
         } catch (Exception e) {
             String result = Utils.uploadPaste(Constants.LAUNCHER_NAME + " Error", xml);
-            App.settings.logStackTrace("Exception when reading a versions XML. See error details at " + result, e);
+            LogManager.logStackTrace("Exception when reading a versions XML. See error details at " + result, e);
         }
         return null;
     }
@@ -505,7 +504,7 @@ public class Pack {
             }
         } catch (Exception e) {
             String result = Utils.uploadPaste(Constants.LAUNCHER_NAME + " Error", xml);
-            App.settings.logStackTrace("Exception when reading a versions XML. See error details at " + result, e);
+            LogManager.logStackTrace("Exception when reading a versions XML. See error details at " + result, e);
         }
         return null;
     }
@@ -530,7 +529,7 @@ public class Pack {
             }
         } catch (Exception e) {
             String result = Utils.uploadPaste(Constants.LAUNCHER_NAME + " Error", xml);
-            App.settings.logStackTrace("Exception when reading a versions XML. See error details at " + result, e);
+            LogManager.logStackTrace("Exception when reading a versions XML. See error details at " + result, e);
         }
         return null;
     }
@@ -555,7 +554,7 @@ public class Pack {
             }
         } catch (Exception e) {
             String result = Utils.uploadPaste(Constants.LAUNCHER_NAME + " Error", xml);
-            App.settings.logStackTrace("Exception when reading a versions XML. See error details at " + result, e);
+            LogManager.logStackTrace("Exception when reading a versions XML. See error details at " + result, e);
         }
         return null;
     }
@@ -579,7 +578,7 @@ public class Pack {
             }
         } catch (Exception e) {
             String result = Utils.uploadPaste(Constants.LAUNCHER_NAME + " Error", xml);
-            App.settings.logStackTrace("Exception when reading a versions XML. See error details at " + result, e);
+            LogManager.logStackTrace("Exception when reading a versions XML. See error details at " + result, e);
         }
         return 0;
     }
@@ -603,7 +602,7 @@ public class Pack {
             }
         } catch (Exception e) {
             String result = Utils.uploadPaste(Constants.LAUNCHER_NAME + " Error", xml);
-            App.settings.logStackTrace("Exception when reading a versions XML. See error details at " + result, e);
+            LogManager.logStackTrace("Exception when reading a versions XML. See error details at " + result, e);
         }
         return null;
     }
@@ -627,7 +626,7 @@ public class Pack {
             }
         } catch (Exception e) {
             String result = Utils.uploadPaste(Constants.LAUNCHER_NAME + " Error", xml);
-            App.settings.logStackTrace("Exception when reading a versions XML. See error details at " + result, e);
+            LogManager.logStackTrace("Exception when reading a versions XML. See error details at " + result, e);
         }
         return true;
     }
@@ -652,7 +651,7 @@ public class Pack {
             }
         } catch (Exception e) {
             String result = Utils.uploadPaste(Constants.LAUNCHER_NAME + " Error", xml);
-            App.settings.logStackTrace("Exception when reading a versions XML. See error details at " + result, e);
+            LogManager.logStackTrace("Exception when reading a versions XML. See error details at " + result, e);
         }
         return null;
     }
@@ -805,11 +804,11 @@ public class Pack {
                 }
             }
         } catch (SAXException e) {
-            App.settings.logStackTrace(e);
+            LogManager.logStackTrace(e);
         } catch (ParserConfigurationException e) {
-            App.settings.logStackTrace(e);
+            LogManager.logStackTrace(e);
         } catch (IOException e) {
-            App.settings.logStackTrace(e);
+            LogManager.logStackTrace(e);
         }
         return mods;
     }
@@ -836,11 +835,11 @@ public class Pack {
                 }
             }
         } catch (SAXException e) {
-            App.settings.logStackTrace(e);
+            LogManager.logStackTrace(e);
         } catch (ParserConfigurationException e) {
-            App.settings.logStackTrace(e);
+            LogManager.logStackTrace(e);
         } catch (IOException e) {
-            App.settings.logStackTrace(e);
+            LogManager.logStackTrace(e);
         }
         return false;
     }
@@ -884,11 +883,11 @@ public class Pack {
                 }
             }
         } catch (SAXException e) {
-            App.settings.logStackTrace(e);
+            LogManager.logStackTrace(e);
         } catch (ParserConfigurationException e) {
-            App.settings.logStackTrace(e);
+            LogManager.logStackTrace(e);
         } catch (IOException e) {
-            App.settings.logStackTrace(e);
+            LogManager.logStackTrace(e);
         }
         return files;
     }
@@ -902,7 +901,7 @@ public class Pack {
         try {
             return Utils.sendAPICall("pack/" + getSafeName() + "/installed/", request);
         } catch (IOException e) {
-            App.settings.logStackTrace(e);
+            LogManager.logStackTrace(e);
         }
         return "Install Not Added!";
     }
@@ -916,7 +915,7 @@ public class Pack {
         try {
             return Utils.sendAPICall("pack/" + getSafeName() + "/serverinstalled/", request);
         } catch (IOException e) {
-            App.settings.logStackTrace(e);
+            LogManager.logStackTrace(e);
         }
         return "Install Not Added!";
     }
@@ -930,7 +929,7 @@ public class Pack {
         try {
             return Utils.sendAPICall("pack/" + getSafeName() + "/updated/", request);
         } catch (IOException e) {
-            App.settings.logStackTrace(e);
+            LogManager.logStackTrace(e);
         }
         return "Install Not Added!";
     }

--- a/src/main/java/com/atlauncher/data/PackUsers.java
+++ b/src/main/java/com/atlauncher/data/PackUsers.java
@@ -18,6 +18,7 @@
 package com.atlauncher.data;
 
 import com.atlauncher.App;
+import com.atlauncher.LogManager;
 import com.atlauncher.annot.Json;
 import com.atlauncher.exceptions.InvalidPack;
 
@@ -34,7 +35,7 @@ public class PackUsers {
         try {
             pack = App.settings.getPackByID(this.pack);
         } catch (InvalidPack e) {
-            App.settings.logStackTrace(e);
+            LogManager.logStackTrace(e);
             return;
         }
         if (this.testers != null) {

--- a/src/main/java/com/atlauncher/data/PackVersion.java
+++ b/src/main/java/com/atlauncher/data/PackVersion.java
@@ -18,6 +18,7 @@
 package com.atlauncher.data;
 
 import com.atlauncher.App;
+import com.atlauncher.LogManager;
 import com.atlauncher.exceptions.InvalidMinecraftVersion;
 
 public class PackVersion {
@@ -42,7 +43,7 @@ public class PackVersion {
             this.minecraftVersion = App.settings.getMinecraftVersion(this.minecraft);
         } catch (InvalidMinecraftVersion e) {
             this.minecraftVersion = null;
-            App.settings.logStackTrace(e);
+            LogManager.logStackTrace(e);
         }
     }
 

--- a/src/main/java/com/atlauncher/data/Settings.java
+++ b/src/main/java/com/atlauncher/data/Settings.java
@@ -54,7 +54,6 @@ import java.awt.Window;
 import java.awt.event.WindowAdapter;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
-import java.io.CharArrayWriter;
 import java.io.EOFException;
 import java.io.File;
 import java.io.FileInputStream;
@@ -67,7 +66,6 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
-import java.io.PrintWriter;
 import java.io.UnsupportedEncodingException;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
@@ -606,7 +604,7 @@ public class Settings {
                 }
             }
         } catch (ParseException e) {
-            this.logStackTrace(e);
+            LogManager.logStackTrace(e);
             minecraftSessionServerUp = false;
             minecraftLoginServerUp = false;
         }
@@ -627,11 +625,11 @@ public class Settings {
             this.latestLauncherVersion = Gsons.DEFAULT.fromJson(new FileReader(new File(this.jsonDir, "version.json")
             ), LauncherVersion.class);
         } catch (JsonSyntaxException e) {
-            this.logStackTrace("Exception when loading latest launcher version!", e);
+            LogManager.logStackTrace("Exception when loading latest launcher version!", e);
         } catch (JsonIOException e) {
-            this.logStackTrace("Exception when loading latest launcher version!", e);
+            LogManager.logStackTrace("Exception when loading latest launcher version!", e);
         } catch (FileNotFoundException e) {
-            this.logStackTrace("Exception when loading latest launcher version!", e);
+            LogManager.logStackTrace("Exception when loading latest launcher version!", e);
         }
 
         return this.latestLauncherVersion != null && Constants.VERSION.needsUpdate(this.latestLauncherVersion);
@@ -655,7 +653,7 @@ public class Settings {
             update.download(false);
             runUpdate(path, newFile.getAbsolutePath());
         } catch (IOException e) {
-            this.logStackTrace(e);
+            LogManager.logStackTrace(e);
         }
     }
 
@@ -681,7 +679,7 @@ public class Settings {
         try {
             processBuilder.start();
         } catch (IOException e) {
-            this.logStackTrace(e);
+            LogManager.logStackTrace(e);
         }
 
         System.exit(0);
@@ -699,7 +697,7 @@ public class Settings {
             this.launcherFiles = Gsons.DEFAULT.fromJson(contents, type);
         } catch (Exception e) {
             String result = Utils.uploadPaste(Constants.LAUNCHER_NAME + " Error", contents);
-            this.logStackTrace("Error loading in file hashes! See error details at " + result, e);
+            LogManager.logStackTrace("Error loading in file hashes! See error details at " + result, e);
         }
     }
 
@@ -748,7 +746,7 @@ public class Settings {
             try {
                 Language.INSTANCE.reload(Language.INSTANCE.getCurrent());
             } catch (IOException e) {
-                logStackTrace("Couldn't reload langauge " + Language.INSTANCE.getCurrent(), e);
+                LogManager.logStackTrace("Couldn't reload langauge " + Language.INSTANCE.getCurrent(), e);
             }
         }
     }
@@ -846,7 +844,7 @@ public class Settings {
 
             this.launcherLibraries = Gsons.DEFAULT.fromJson(fr, type);
         } catch (Exception e) {
-            logStackTrace(e);
+            LogManager.logStackTrace(e);
         } finally {
             if (fr != null) {
                 try {
@@ -1162,9 +1160,9 @@ public class Settings {
                 this.originalServer = this.server;
             }
         } catch (FileNotFoundException e) {
-            logStackTrace(e);
+            LogManager.logStackTrace(e);
         } catch (IOException e) {
-            logStackTrace(e);
+            LogManager.logStackTrace(e);
         }
         LogManager.debug("Finished loading server to use");
     }
@@ -1239,9 +1237,9 @@ public class Settings {
                 this.daysOfLogsToKeep = 7;
             }
         } catch (FileNotFoundException e) {
-            logStackTrace(e);
+            LogManager.logStackTrace(e);
         } catch (IOException e) {
-            logStackTrace(e);
+            LogManager.logStackTrace(e);
         }
     }
 
@@ -1456,9 +1454,9 @@ public class Settings {
             this.notifyBackup = Boolean.parseBoolean(properties.getProperty("notifybackup", "true"));
             this.dropboxFolderLocation = properties.getProperty("dropboxlocation", "");
         } catch (FileNotFoundException e) {
-            logStackTrace(e);
+            LogManager.logStackTrace(e);
         } catch (IOException e) {
-            logStackTrace(e);
+            LogManager.logStackTrace(e);
         }
         LogManager.debug("Finished loading properties");
     }
@@ -1515,9 +1513,9 @@ public class Settings {
             properties.setProperty("dropboxlocation", this.dropboxFolderLocation);
             this.properties.store(new FileOutputStream(propertiesFile), Constants.LAUNCHER_NAME + " Settings");
         } catch (FileNotFoundException e) {
-            logStackTrace(e);
+            LogManager.logStackTrace(e);
         } catch (IOException e) {
-            logStackTrace(e);
+            LogManager.logStackTrace(e);
         }
     }
 
@@ -1614,15 +1612,15 @@ public class Settings {
             this.news = Gsons.DEFAULT.fromJson(in, type);
             in.close();
         } catch (JsonSyntaxException e) {
-            logStackTrace(e);
+            LogManager.logStackTrace(e);
         } catch (JsonIOException e) {
-            logStackTrace(e);
+            LogManager.logStackTrace(e);
         } catch (FileNotFoundException e) {
-            logStackTrace(e);
+            LogManager.logStackTrace(e);
         } catch (UnsupportedEncodingException e) {
-            logStackTrace(e);
+            LogManager.logStackTrace(e);
         } catch (IOException e) {
-            logStackTrace(e);
+            LogManager.logStackTrace(e);
         }
         LogManager.debug("Finished loading news");
     }
@@ -1649,11 +1647,11 @@ public class Settings {
                 this.minecraftVersions.put(mv.getVersion(), mv);
             }
         } catch (JsonSyntaxException e) {
-            logStackTrace(e);
+            LogManager.logStackTrace(e);
         } catch (JsonIOException e) {
-            logStackTrace(e);
+            LogManager.logStackTrace(e);
         } catch (FileNotFoundException e) {
-            logStackTrace(e);
+            LogManager.logStackTrace(e);
         }
         LogManager.debug("Finished loading Minecraft versions");
     }
@@ -1668,11 +1666,11 @@ public class Settings {
             }.getType();
             this.packs = Gsons.DEFAULT.fromJson(new FileReader(new File(getJSONDir(), "packs.json")), type);
         } catch (JsonSyntaxException e) {
-            logStackTrace(e);
+            LogManager.logStackTrace(e);
         } catch (JsonIOException e) {
-            logStackTrace(e);
+            LogManager.logStackTrace(e);
         } catch (FileNotFoundException e) {
-            logStackTrace(e);
+            LogManager.logStackTrace(e);
         }
         LogManager.debug("Finished loading packs");
     }
@@ -1689,9 +1687,9 @@ public class Settings {
             }.getType();
             packUsers = Gsons.DEFAULT.fromJson(download.getContents(), type);
         } catch (JsonSyntaxException e) {
-            logStackTrace(e);
+            LogManager.logStackTrace(e);
         } catch (JsonIOException e) {
-            logStackTrace(e);
+            LogManager.logStackTrace(e);
         }
         if (packUsers == null) {
             this.offlineMode = true;
@@ -1743,7 +1741,7 @@ public class Settings {
                     in.close();
                 }
             } catch (Exception e) {
-                logStackTrace(e);
+                LogManager.logStackTrace(e);
             }
             saveInstances(); // Save the instances to new json format
             Utils.delete(instancesDataFile); // Remove old instances data file
@@ -1758,7 +1756,7 @@ public class Settings {
                     fileReader = new FileReader(new File(instanceDir, "instance.json"));
                     instance = Gsons.DEFAULT.fromJson(fileReader, Instance.class);
                 } catch (Exception e) {
-                    logStackTrace("Failed to load instance in the folder " + instanceDir, e);
+                    LogManager.logStackTrace("Failed to load instance in the folder " + instanceDir, e);
                     continue; // Instance.json not found for some reason, continue before loading
                 }
 
@@ -1801,7 +1799,7 @@ public class Settings {
                 bw = new BufferedWriter(fw);
                 bw.write(Gsons.DEFAULT.toJson(instance));
             } catch (IOException e) {
-                App.settings.logStackTrace(e);
+                LogManager.logStackTrace(e);
             } finally {
                 try {
                     if (bw != null) {
@@ -1811,7 +1809,7 @@ public class Settings {
                         fw.close();
                     }
                 } catch (IOException e) {
-                    logStackTrace("Exception while trying to close FileWriter/BufferedWriter for saving instances " +
+                    LogManager.logStackTrace("Exception while trying to close FileWriter/BufferedWriter for saving instances " +
                         "json file.", e);
                 }
             }
@@ -1838,9 +1836,9 @@ public class Settings {
             } catch (EOFException e) {
                 // Don't log this, it always happens when it gets to the end of the file
             } catch (IOException e) {
-                logStackTrace("Exception while trying to read accounts in from file.", e);
+                LogManager.logStackTrace("Exception while trying to read accounts in from file.", e);
             } catch (ClassNotFoundException e) {
-                logStackTrace("Exception while trying to read accounts in from file.", e);
+                LogManager.logStackTrace("Exception while trying to read accounts in from file.", e);
             } finally {
                 try {
                     if (objIn != null) {
@@ -1850,7 +1848,7 @@ public class Settings {
                         in.close();
                     }
                 } catch (IOException e) {
-                    logStackTrace("Exception while trying to close FileInputStream/ObjectInputStream when reading in " +
+                    LogManager.logStackTrace("Exception while trying to close FileInputStream/ObjectInputStream when reading in " +
                         "" + "accounts.", e);
                 }
             }
@@ -1868,7 +1866,7 @@ public class Settings {
                 objOut.writeObject(account);
             }
         } catch (IOException e) {
-            logStackTrace(e);
+            LogManager.logStackTrace(e);
         } finally {
             try {
                 if (objOut != null) {
@@ -1878,7 +1876,7 @@ public class Settings {
                     out.close();
                 }
             } catch (IOException e) {
-                logStackTrace("Exception while trying to close FileOutputStream/ObjectOutputStream when saving " +
+                LogManager.logStackTrace("Exception while trying to close FileOutputStream/ObjectOutputStream when saving " +
                     "accounts.", e);
             }
         }
@@ -1904,7 +1902,7 @@ public class Settings {
             try {
                 fileReader = new FileReader(checkingServersFile);
             } catch (FileNotFoundException e) {
-                logStackTrace(e);
+                LogManager.logStackTrace(e);
                 return;
             }
 
@@ -1914,7 +1912,7 @@ public class Settings {
                 try {
                     fileReader.close();
                 } catch (IOException e) {
-                    logStackTrace("Exception while trying to close FileReader when loading servers for server " +
+                    LogManager.logStackTrace("Exception while trying to close FileReader when loading servers for server " +
                         "checker" + " tool.", e);
                 }
             }
@@ -1934,7 +1932,7 @@ public class Settings {
             bw = new BufferedWriter(fw);
             bw.write(Gsons.DEFAULT.toJson(this.checkingServers));
         } catch (IOException e) {
-            App.settings.logStackTrace(e);
+            LogManager.logStackTrace(e);
         } finally {
             try {
                 if (bw != null) {
@@ -1944,7 +1942,7 @@ public class Settings {
                     fw.close();
                 }
             } catch (IOException e) {
-                logStackTrace("Exception while trying to close FileWriter/BufferedWriter when saving servers for " +
+                LogManager.logStackTrace("Exception while trying to close FileWriter/BufferedWriter when saving servers for " +
                     "server checker tool.", e);
             }
         }
@@ -2612,35 +2610,7 @@ public class Settings {
     public String getLog() {
         return this.console.getLog();
     }
-
-    /**
-     * Logs a stack trace to the console window
-     *
-     * @param t The throwable to show in the console
-     */
-    public void logStackTrace(Throwable t) {
-        t.printStackTrace();
-
-        CharArrayWriter writer = new CharArrayWriter();
-        try {
-            t.printStackTrace(new PrintWriter(writer));
-            LogManager.error(writer.toString());
-        } finally {
-            writer.close();
-        }
-    }
-
-    /**
-     * Logs a stack trace to the console window with a custom message before it
-     *
-     * @param message   A message regarding the stack trace to show before it providing more insight
-     * @param t The throwable to show in the console
-     */
-    public void logStackTrace(String message, Throwable t) {
-        LogManager.error(message);
-        logStackTrace(t);
-    }
-
+    
     public void showKillMinecraft(Process minecraft) {
         this.minecraftProcess = minecraft;
         this.console.showKillMinecraft();
@@ -3100,9 +3070,9 @@ public class Settings {
             path = thisFile.getCanonicalPath();
             path = URLDecoder.decode(path, "UTF-8");
         } catch (UnsupportedEncodingException e) {
-            logStackTrace(e);
+            LogManager.logStackTrace(e);
         } catch (IOException e) {
-            logStackTrace(e);
+            LogManager.logStackTrace(e);
         }
 
         List<String> arguments = new ArrayList<String>();

--- a/src/main/java/com/atlauncher/data/Settings.java
+++ b/src/main/java/com/atlauncher/data/Settings.java
@@ -17,37 +17,6 @@
  */
 package com.atlauncher.data;
 
-import com.atlauncher.App;
-import com.atlauncher.Gsons;
-import com.atlauncher.LogManager;
-import com.atlauncher.Update;
-import com.atlauncher.data.json.LauncherLibrary;
-import com.atlauncher.exceptions.InvalidMinecraftVersion;
-import com.atlauncher.exceptions.InvalidPack;
-import com.atlauncher.gui.LauncherConsole;
-import com.atlauncher.gui.components.LauncherBottomBar;
-import com.atlauncher.gui.dialogs.ProgressDialog;
-import com.atlauncher.gui.tabs.InstancesTab;
-import com.atlauncher.gui.tabs.NewsTab;
-import com.atlauncher.gui.tabs.PacksTab;
-import com.atlauncher.thread.LoggingThread;
-import com.atlauncher.utils.ATLauncherAPIUtils;
-import com.atlauncher.utils.HTMLUtils;
-import com.atlauncher.utils.MojangAPIUtils;
-import com.atlauncher.utils.Timestamper;
-import com.atlauncher.utils.Utils;
-import com.google.gson.JsonIOException;
-import com.google.gson.JsonSyntaxException;
-import com.google.gson.reflect.TypeToken;
-import org.json.simple.JSONArray;
-import org.json.simple.JSONObject;
-import org.json.simple.parser.JSONParser;
-import org.json.simple.parser.ParseException;
-
-import javax.swing.JDialog;
-import javax.swing.JFrame;
-import javax.swing.JLabel;
-import javax.swing.JOptionPane;
 import java.awt.Dialog.ModalityType;
 import java.awt.FlowLayout;
 import java.awt.Window;
@@ -88,6 +57,40 @@ import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+
+import javax.swing.JDialog;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+
+import com.atlauncher.App;
+import com.atlauncher.Gsons;
+import com.atlauncher.LogManager;
+import com.atlauncher.Update;
+import com.atlauncher.data.json.LauncherLibrary;
+import com.atlauncher.exceptions.InvalidMinecraftVersion;
+import com.atlauncher.exceptions.InvalidPack;
+import com.atlauncher.gui.LauncherConsole;
+import com.atlauncher.gui.components.LauncherBottomBar;
+import com.atlauncher.gui.dialogs.ProgressDialog;
+import com.atlauncher.gui.tabs.InstancesTab;
+import com.atlauncher.gui.tabs.NewsTab;
+import com.atlauncher.gui.tabs.PacksTab;
+import com.atlauncher.thread.LoggingThread;
+import com.atlauncher.utils.ATLauncherAPIUtils;
+import com.atlauncher.utils.HTMLUtils;
+import com.atlauncher.utils.MojangAPIUtils;
+import com.atlauncher.utils.Timestamper;
+import com.atlauncher.utils.Utils;
+
+import com.google.gson.JsonIOException;
+import com.google.gson.JsonSyntaxException;
+import com.google.gson.reflect.TypeToken;
+
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
 
 /**
  * Settings class for storing all data for the Launcher and the settings of the user.
@@ -834,24 +837,23 @@ public class Settings {
     private void downloadExternalLibraries() {
         LogManager.debug("Downloading external libraries");
 
-        FileReader fr = null;
-
+        FileReader fr;
         try {
             fr = new FileReader(new File(this.jsonDir, "libraries.json"));
+        } catch (FileNotFoundException e) {
+            LogManager.logStackTrace("Missing libraries.json", e);
+            return;
+        }
 
-            java.lang.reflect.Type type = new TypeToken<List<LauncherLibrary>>() {
-            }.getType();
+        try {
+            java.lang.reflect.Type type = new TypeToken<List<LauncherLibrary>>() {}.getType();
 
             this.launcherLibraries = Gsons.DEFAULT.fromJson(fr, type);
-        } catch (Exception e) {
-            LogManager.logStackTrace(e);
         } finally {
-            if (fr != null) {
-                try {
-                    fr.close();
-                } catch (IOException e) {
-                    e.printStackTrace();
-                }
+            try {
+                fr.close();
+            } catch (IOException e) {
+                LogManager.logStackTrace(e);
             }
         }
 
@@ -2638,8 +2640,8 @@ public class Settings {
     public void setLanguage(String language) {
         try {
             Language.INSTANCE.load(language);
-        } catch (Exception ex) {
-            ex.printStackTrace(System.err);
+        } catch (IOException ex) {
+            LogManager.logStackTrace("Failed to load language", ex);
         }
     }
 
@@ -3098,7 +3100,7 @@ public class Settings {
         try {
             processBuilder.start();
         } catch (IOException e) {
-            e.printStackTrace();
+            LogManager.logStackTrace("Failed to start updater process", e);
         }
         System.exit(0);
     }

--- a/src/main/java/com/atlauncher/data/mojang/api/MinecraftProfileResponse.java
+++ b/src/main/java/com/atlauncher/data/mojang/api/MinecraftProfileResponse.java
@@ -17,7 +17,7 @@
  */
 package com.atlauncher.data.mojang.api;
 
-import com.atlauncher.App;
+import com.atlauncher.LogManager;
 import com.atlauncher.annot.Json;
 
 import java.io.IOException;
@@ -39,7 +39,7 @@ public class MinecraftProfileResponse {
                 try {
                     return property.parse();
                 } catch (IOException e) {
-                    App.settings.logStackTrace("Error parsing user property " + name + " for username " + name, e);
+                    LogManager.logStackTrace("Error parsing user property " + name + " for username " + name, e);
                 }
             }
         }

--- a/src/main/java/com/atlauncher/gui/card/InstanceCard.java
+++ b/src/main/java/com/atlauncher/gui/card/InstanceCard.java
@@ -18,38 +18,6 @@
 
 package com.atlauncher.gui.card;
 
-import com.atlauncher.App;
-import com.atlauncher.Gsons;
-import com.atlauncher.LogManager;
-import com.atlauncher.data.APIResponse;
-import com.atlauncher.data.Instance;
-import com.atlauncher.data.Language;
-import com.atlauncher.evnt.listener.RelocalizationListener;
-import com.atlauncher.evnt.manager.RelocalizationManager;
-import com.atlauncher.gui.components.CollapsiblePanel;
-import com.atlauncher.gui.components.ImagePanel;
-import com.atlauncher.gui.dialogs.BackupDialog;
-import com.atlauncher.gui.dialogs.EditModsDialog;
-import com.atlauncher.gui.dialogs.InstanceInstallerDialog;
-import com.atlauncher.gui.dialogs.ProgressDialog;
-import com.atlauncher.gui.dialogs.RenameInstanceDialog;
-import com.atlauncher.utils.HTMLUtils;
-import com.atlauncher.utils.Utils;
-
-import javax.swing.BorderFactory;
-import javax.swing.JButton;
-import javax.swing.JDialog;
-import javax.swing.JFileChooser;
-import javax.swing.JLabel;
-import javax.swing.JMenuItem;
-import javax.swing.JOptionPane;
-import javax.swing.JPanel;
-import javax.swing.JPopupMenu;
-import javax.swing.JProgressBar;
-import javax.swing.JScrollPane;
-import javax.swing.JSplitPane;
-import javax.swing.JTextArea;
-import javax.swing.filechooser.FileNameExtensionFilter;
 import java.awt.BorderLayout;
 import java.awt.Cursor;
 import java.awt.Dialog.ModalityType;
@@ -68,6 +36,39 @@ import java.io.File;
 import java.io.IOException;
 import java.sql.Timestamp;
 import java.util.Date;
+
+import javax.swing.BorderFactory;
+import javax.swing.JButton;
+import javax.swing.JDialog;
+import javax.swing.JFileChooser;
+import javax.swing.JLabel;
+import javax.swing.JMenuItem;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JPopupMenu;
+import javax.swing.JProgressBar;
+import javax.swing.JScrollPane;
+import javax.swing.JSplitPane;
+import javax.swing.JTextArea;
+import javax.swing.filechooser.FileNameExtensionFilter;
+
+import com.atlauncher.App;
+import com.atlauncher.Gsons;
+import com.atlauncher.LogManager;
+import com.atlauncher.data.APIResponse;
+import com.atlauncher.data.Instance;
+import com.atlauncher.data.Language;
+import com.atlauncher.evnt.listener.RelocalizationListener;
+import com.atlauncher.evnt.manager.RelocalizationManager;
+import com.atlauncher.gui.components.CollapsiblePanel;
+import com.atlauncher.gui.components.ImagePanel;
+import com.atlauncher.gui.dialogs.BackupDialog;
+import com.atlauncher.gui.dialogs.EditModsDialog;
+import com.atlauncher.gui.dialogs.InstanceInstallerDialog;
+import com.atlauncher.gui.dialogs.ProgressDialog;
+import com.atlauncher.gui.dialogs.RenameInstanceDialog;
+import com.atlauncher.utils.HTMLUtils;
+import com.atlauncher.utils.Utils;
 
 /**
  * <p/>
@@ -479,8 +480,8 @@ public class InstanceCard extends CollapsiblePanel implements RelocalizationList
                                         Utils.safeCopy(img, new File(instance.getRootDirectory(), "instance.png"));
                                         image.setImage(instance.getImage().getImage());
                                         instance.save();
-                                    } catch (IOException e1) {
-                                        e1.printStackTrace(System.err);
+                                    } catch (IOException ex) {
+                                        LogManager.logStackTrace("Failed to set instance image", ex);
                                     }
                                 }
                             }
@@ -530,7 +531,7 @@ public class InstanceCard extends CollapsiblePanel implements RelocalizationList
                     shareCodeItem.addActionListener(new ActionListener() {
                         @Override
                         public void actionPerformed(ActionEvent e) {
-                            if (instance.getInstalledOptionalModNames().size() > 0) {
+                            if (!instance.getInstalledOptionalModNames().isEmpty()) {
                                 try {
                                     APIResponse response = Gsons.DEFAULT.fromJson(Utils.sendAPICall("pack/" +
                                             instance.getRealPack().getSafeName() + "/" + instance.getVersion() +
@@ -546,8 +547,8 @@ public class InstanceCard extends CollapsiblePanel implements RelocalizationList
                                         App.TOASTER.pop(Language.INSTANCE.localize("instance.sharecodecopied"));
                                         LogManager.info("Share code copied to clipboard");
                                     }
-                                } catch (IOException e1) {
-                                    e1.printStackTrace();
+                                } catch (IOException ex) {
+                                    LogManager.logStackTrace("API call failed", ex);
                                 }
                             } else {
                                 App.TOASTER.pop(Language.INSTANCE.localize("instance.nooptionalmods"));

--- a/src/main/java/com/atlauncher/gui/card/ModCard.java
+++ b/src/main/java/com/atlauncher/gui/card/ModCard.java
@@ -18,10 +18,6 @@
 
 package com.atlauncher.gui.card;
 
-import com.atlauncher.data.Mod;
-import com.atlauncher.utils.Utils;
-
-import javax.swing.JPanel;
 import java.awt.Color;
 import java.awt.Cursor;
 import java.awt.Dimension;
@@ -29,6 +25,11 @@ import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
+
+import javax.swing.JPanel;
+
+import com.atlauncher.data.Mod;
+import com.atlauncher.utils.Utils;
 
 public final class ModCard extends JPanel {
     public final Mod mod;
@@ -45,15 +46,9 @@ public final class ModCard extends JPanel {
             public void mouseClicked(MouseEvent e) {
                 super.mouseClicked(e);
                 if (ModCard.this.mod.hasWebsite()) {
-                    try {
-                        Utils.openBrowser(mod.getWebsite());
-                    } catch (Exception e1) {
-                        e1.printStackTrace(System.err);
-                    }
+                    Utils.openBrowser(mod.getWebsite());
                 }
             }
-
-
         });
     }
 

--- a/src/main/java/com/atlauncher/gui/components/Console.java
+++ b/src/main/java/com/atlauncher/gui/components/Console.java
@@ -18,10 +18,12 @@
 
 package com.atlauncher.gui.components;
 
+import java.awt.Color;
+
 import javax.swing.JTextPane;
+import javax.swing.text.BadLocationException;
 import javax.swing.text.SimpleAttributeSet;
 import javax.swing.text.StyleConstants;
-import java.awt.Color;
 
 public final class Console extends JTextPane {
     /**
@@ -53,7 +55,7 @@ public final class Console extends JTextPane {
         try {
             this.getDocument().insertString(this.getDocument().getLength(), str, this.attrs);
             this.setCaretPosition(this.getDocument().getLength());
-        } catch (Exception ex) {
+        } catch (BadLocationException ex) {
             ex.printStackTrace(System.err);
         }
     }

--- a/src/main/java/com/atlauncher/gui/dialogs/EditModsDialog.java
+++ b/src/main/java/com/atlauncher/gui/dialogs/EditModsDialog.java
@@ -36,6 +36,7 @@ import javax.swing.JSplitPane;
 import javax.swing.SwingConstants;
 
 import com.atlauncher.App;
+import com.atlauncher.LogManager;
 import com.atlauncher.data.DisableableMod;
 import com.atlauncher.data.Instance;
 import com.atlauncher.data.Language;
@@ -66,7 +67,7 @@ public class EditModsDialog extends JDialog {
         setDefaultCloseOperation(JDialog.DISPOSE_ON_CLOSE);
         addWindowListener(new WindowAdapter() {
             @Override
-			public void windowClosing(WindowEvent arg0) {
+            public void windowClosing(WindowEvent arg0) {
                 dispose();
             }
         });
@@ -131,26 +132,21 @@ public class EditModsDialog extends JDialog {
         addButton = new JButton(Language.INSTANCE.localize("instance.addmod"));
         addButton.addActionListener(new ActionListener() {
             @Override
-			public void actionPerformed(ActionEvent e) {
+            public void actionPerformed(ActionEvent e) {
                 FileChooserDialog fcd = null;
                 boolean usesCoreMods = false;
                 try {
-                	if (App.settings.getMinecraftVersion(instance.getMinecraftVersion()).usesCoreMods()) {
-						usesCoreMods = true;
-					} else {
-						usesCoreMods = false;
-					}
+                    usesCoreMods = App.settings.getMinecraftVersion(instance.getMinecraftVersion()).usesCoreMods();
                 } catch (InvalidMinecraftVersion e1) {
-					// TODO Auto-generated catch block
-					e1.printStackTrace();
-				}
+                    LogManager.logStackTrace(e1);
+                }
                 if(usesCoreMods) {
-                	fcd = new FileChooserDialog(Language.INSTANCE.localize("instance.addmod"), Language
+                    fcd = new FileChooserDialog(Language.INSTANCE.localize("instance.addmod"), Language
                             .INSTANCE.localize("common.mod"), Language.INSTANCE.localize("common.add"), Language.INSTANCE
                             .localize("instance.typeofmod"), new String[]{"Mods Folder", "Inside Minecraft.jar",
                             "CoreMods Mod", "Texture Pack", "Shader Pack"}, new String[]{"jar", "zip", "litemod"});
                 } else {
-                	new FileChooserDialog(Language.INSTANCE.localize("instance.addmod"), Language
+                    new FileChooserDialog(Language.INSTANCE.localize("instance.addmod"), Language
                             .INSTANCE.localize("common.mod"), Language.INSTANCE.localize("common.add"), Language.INSTANCE
                             .localize("instance.typeofmod"), new String[]{"Mods Folder", "Inside Minecraft.jar",
                             "Resource Pack", "Shader Pack"}, new String[]{"jar", "zip", "litemod"});
@@ -195,7 +191,7 @@ public class EditModsDialog extends JDialog {
         enableButton = new JButton(Language.INSTANCE.localize("instance.enablemod"));
         enableButton.addActionListener(new ActionListener() {
             @Override
-			public void actionPerformed(ActionEvent e) {
+            public void actionPerformed(ActionEvent e) {
                 enableMods();
             }
         });
@@ -204,7 +200,7 @@ public class EditModsDialog extends JDialog {
         disableButton = new JButton(Language.INSTANCE.localize("instance.disablemod"));
         disableButton.addActionListener(new ActionListener() {
             @Override
-			public void actionPerformed(ActionEvent e) {
+            public void actionPerformed(ActionEvent e) {
                 disableMods();
             }
         });
@@ -213,7 +209,7 @@ public class EditModsDialog extends JDialog {
         removeButton = new JButton(Language.INSTANCE.localize("instance.removemod"));
         removeButton.addActionListener(new ActionListener() {
             @Override
-			public void actionPerformed(ActionEvent e) {
+            public void actionPerformed(ActionEvent e) {
                 removeMods();
             }
         });
@@ -222,7 +218,7 @@ public class EditModsDialog extends JDialog {
         closeButton = new JButton(Language.INSTANCE.localize("common.close"));
         closeButton.addActionListener(new ActionListener() {
             @Override
-			public void actionPerformed(ActionEvent e) {
+            public void actionPerformed(ActionEvent e) {
                 dispose();
             }
         });

--- a/src/main/java/com/atlauncher/gui/dialogs/EditModsDialog.java
+++ b/src/main/java/com/atlauncher/gui/dialogs/EditModsDialog.java
@@ -133,26 +133,29 @@ public class EditModsDialog extends JDialog {
         addButton.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent e) {
-                FileChooserDialog fcd = null;
                 boolean usesCoreMods = false;
                 try {
                     usesCoreMods = App.settings.getMinecraftVersion(instance.getMinecraftVersion()).usesCoreMods();
                 } catch (InvalidMinecraftVersion e1) {
                     LogManager.logStackTrace(e1);
                 }
-                if(usesCoreMods) {
-                    fcd = new FileChooserDialog(Language.INSTANCE.localize("instance.addmod"), Language
-                            .INSTANCE.localize("common.mod"), Language.INSTANCE.localize("common.add"), Language.INSTANCE
-                            .localize("instance.typeofmod"), new String[]{"Mods Folder", "Inside Minecraft.jar",
-                            "CoreMods Mod", "Texture Pack", "Shader Pack"}, new String[]{"jar", "zip", "litemod"});
+                String[] modTypes;
+                if (usesCoreMods) {
+                    modTypes = new String[] {"Mods Folder", "Inside Minecraft.jar", "CoreMods Mod", "Texture Pack", "Shader Pack"};
                 } else {
-                    new FileChooserDialog(Language.INSTANCE.localize("instance.addmod"), Language
-                            .INSTANCE.localize("common.mod"), Language.INSTANCE.localize("common.add"), Language.INSTANCE
-                            .localize("instance.typeofmod"), new String[]{"Mods Folder", "Inside Minecraft.jar",
-                            "Resource Pack", "Shader Pack"}, new String[]{"jar", "zip", "litemod"});
+                    modTypes = new String[] {"Mods Folder", "Inside Minecraft.jar", "Resource Pack", "Shader Pack"};
                 }
+
+                FileChooserDialog fcd = new FileChooserDialog(
+                    Language.INSTANCE.localize("instance.addmod"),
+                    Language.INSTANCE.localize("common.mod"),
+                    Language.INSTANCE.localize("common.add"),
+                    Language.INSTANCE.localize("instance.typeofmod"),
+                    modTypes,
+                    new String[] {"jar", "zip", "litemod"}
+                );
                 ArrayList<File> files = fcd.getChosenFiles();
-                if (files != null && files.size() >= 1) {
+                if (files != null && !files.isEmpty()) {
                     boolean reload = false;
                     for (File file : files) {
                         String typeTemp = fcd.getSelectorValue();

--- a/src/main/java/com/atlauncher/gui/dialogs/GithubIssueReporterDialog.java
+++ b/src/main/java/com/atlauncher/gui/dialogs/GithubIssueReporterDialog.java
@@ -18,11 +18,9 @@
 
 package com.atlauncher.gui.dialogs;
 
-import com.atlauncher.App;
-import com.atlauncher.data.Constants;
-import com.atlauncher.data.Language;
-import com.atlauncher.gui.components.ToolsPanel;
-import com.atlauncher.reporter.GithubIssueReporter;
+import java.awt.BorderLayout;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
 
 import javax.swing.JButton;
 import javax.swing.JDialog;
@@ -31,9 +29,12 @@ import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
 import javax.swing.JTextField;
 import javax.swing.WindowConstants;
-import java.awt.BorderLayout;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
+
+import com.atlauncher.App;
+import com.atlauncher.data.Constants;
+import com.atlauncher.data.Language;
+import com.atlauncher.gui.components.ToolsPanel;
+import com.atlauncher.reporter.GithubIssueReporter;
 
 public final class GithubIssueReporterDialog extends JDialog {
     private final JTextField TITLE_FIELD = new JTextField(16);
@@ -58,12 +59,12 @@ public final class GithubIssueReporterDialog extends JDialog {
                     @Override
                     public void run() {
                         try {
-                            GithubIssueReporter.submit(TITLE_FIELD.getText() + " - " + Constants.VERSION, INFO_AREA
-                                    .getText());
-                        } catch (Exception e1) {
-                            e1.printStackTrace(System.err);
+                            GithubIssueReporter.submit(TITLE_FIELD.getText() + " - " + Constants.VERSION, INFO_AREA.getText());
+                        } catch (InterruptedException ignored) {
+                            Thread.currentThread().interrupt();
+                        } finally {
+                            dispose();
                         }
-                        dispose();
                     }
                 });
             }

--- a/src/main/java/com/atlauncher/gui/dialogs/InstanceInstallerDialog.java
+++ b/src/main/java/com/atlauncher/gui/dialogs/InstanceInstallerDialog.java
@@ -18,6 +18,7 @@
 package com.atlauncher.gui.dialogs;
 
 import com.atlauncher.App;
+import com.atlauncher.LogManager;
 import com.atlauncher.data.Instance;
 import com.atlauncher.data.Language;
 import com.atlauncher.data.Pack;
@@ -334,9 +335,9 @@ public class InstanceInstallerDialog extends JDialog {
                             try {
                                 success = get();
                             } catch (InterruptedException e) {
-                                App.settings.logStackTrace(e);
+                                LogManager.logStackTrace(e);
                             } catch (ExecutionException e) {
-                                App.settings.logStackTrace(e);
+                                LogManager.logStackTrace(e);
                             }
                             if (success) {
                                 type = JOptionPane.INFORMATION_MESSAGE;

--- a/src/main/java/com/atlauncher/gui/dialogs/InstanceInstallerDialog.java
+++ b/src/main/java/com/atlauncher/gui/dialogs/InstanceInstallerDialog.java
@@ -17,25 +17,6 @@
  */
 package com.atlauncher.gui.dialogs;
 
-import com.atlauncher.App;
-import com.atlauncher.LogManager;
-import com.atlauncher.data.Instance;
-import com.atlauncher.data.Language;
-import com.atlauncher.data.Pack;
-import com.atlauncher.data.PackVersion;
-import com.atlauncher.utils.HTMLUtils;
-import com.atlauncher.utils.Utils;
-import com.atlauncher.workers.InstanceInstaller;
-
-import javax.swing.JButton;
-import javax.swing.JCheckBox;
-import javax.swing.JComboBox;
-import javax.swing.JDialog;
-import javax.swing.JLabel;
-import javax.swing.JOptionPane;
-import javax.swing.JPanel;
-import javax.swing.JProgressBar;
-import javax.swing.JTextField;
 import java.awt.BorderLayout;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
@@ -49,6 +30,26 @@ import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.util.ArrayList;
 import java.util.concurrent.ExecutionException;
+
+import javax.swing.JButton;
+import javax.swing.JCheckBox;
+import javax.swing.JComboBox;
+import javax.swing.JDialog;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JProgressBar;
+import javax.swing.JTextField;
+
+import com.atlauncher.App;
+import com.atlauncher.LogManager;
+import com.atlauncher.data.Instance;
+import com.atlauncher.data.Language;
+import com.atlauncher.data.Pack;
+import com.atlauncher.data.PackVersion;
+import com.atlauncher.utils.HTMLUtils;
+import com.atlauncher.utils.Utils;
+import com.atlauncher.workers.InstanceInstaller;
 
 public class InstanceInstallerDialog extends JDialog {
     private static final long serialVersionUID = -6984886874482721558L;
@@ -334,8 +335,9 @@ public class InstanceInstallerDialog extends JDialog {
                         } else {
                             try {
                                 success = get();
-                            } catch (InterruptedException e) {
-                                LogManager.logStackTrace(e);
+                            } catch (InterruptedException ignored) {
+                                Thread.currentThread().interrupt();
+                                return;
                             } catch (ExecutionException e) {
                                 LogManager.logStackTrace(e);
                             }

--- a/src/main/java/com/atlauncher/mclauncher/LegacyMCLauncher.java
+++ b/src/main/java/com/atlauncher/mclauncher/LegacyMCLauncher.java
@@ -407,12 +407,6 @@ public class LegacyMCLauncher {
                 } catch (InstantiationException e) {
                     System.out.println("Applet wrapper failed! Falling back " + "to compatibility mode.");
                     mc.getMethod("main", String[].class).invoke(null, (Object) mcArgs);
-                } finally {
-                    try {
-                        cl.close();
-                    } catch (IOException e) {
-                        e.printStackTrace();
-                    }
                 }
             }
         } catch (ClassNotFoundException e) {

--- a/src/main/java/com/atlauncher/mclauncher/LegacyMCLauncher.java
+++ b/src/main/java/com/atlauncher/mclauncher/LegacyMCLauncher.java
@@ -190,10 +190,10 @@ public class LegacyMCLauncher {
             pathh = URLDecoder.decode(pathh, "UTF-8");
         } catch (UnsupportedEncodingException e) {
             pathh = System.getProperty("java.class.path");
-            App.settings.logStackTrace(e);
+            LogManager.logStackTrace(e);
         } catch (IOException e) {
             pathh = System.getProperty("java.class.path");
-            App.settings.logStackTrace(e);
+            LogManager.logStackTrace(e);
         }
         System.out.println(System.getProperty("java.class.path"));
         arguments.add(pathh + cpb.toString());

--- a/src/main/java/com/atlauncher/mclauncher/MCFrame.java
+++ b/src/main/java/com/atlauncher/mclauncher/MCFrame.java
@@ -17,9 +17,6 @@
  */
 package com.atlauncher.mclauncher;
 
-import com.atlauncher.utils.Utils;
-import net.minecraft.Launcher;
-
 import java.applet.Applet;
 import java.awt.Dimension;
 import java.awt.Frame;
@@ -27,6 +24,10 @@ import java.awt.event.WindowEvent;
 import java.awt.event.WindowListener;
 import java.net.MalformedURLException;
 import java.net.URL;
+
+import com.atlauncher.utils.Utils;
+
+import net.minecraft.Launcher;
 
 public class MCFrame extends Frame implements WindowListener {
 
@@ -76,11 +77,13 @@ public class MCFrame extends Frame implements WindowListener {
     @Override
     public void windowClosing(WindowEvent e) {
         new Thread() {
+            @Override
             public void run() {
                 try {
                     Thread.sleep(30000L);
-                } catch (InterruptedException localInterruptedException) {
-                    localInterruptedException.printStackTrace();
+                } catch (InterruptedException ignored) {
+                    Thread.currentThread().interrupt();
+                    return;
                 }
                 System.out.println("FORCING EXIT!");
                 System.exit(0);

--- a/src/main/java/com/atlauncher/reporter/GithubIssueReporter.java
+++ b/src/main/java/com/atlauncher/reporter/GithubIssueReporter.java
@@ -18,6 +18,11 @@
 
 package com.atlauncher.reporter;
 
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
 import com.atlauncher.App;
 import com.atlauncher.Gsons;
 import com.atlauncher.LogManager;
@@ -25,18 +30,20 @@ import com.atlauncher.data.APIResponse;
 import com.atlauncher.thread.PasteUpload;
 import com.atlauncher.utils.Utils;
 
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
-
 public final class GithubIssueReporter {
     private GithubIssueReporter() {
     }
 
-    public static void submit(String title, String body) throws Exception {
+    public static void submit(String title, String message) throws InterruptedException {
         if (App.settings != null && App.settings.enableLogs()) {
-            body = body + "\n\n" + times('-', 50) + "\n" + "Here is my log: " + App.TASKPOOL.submit(new PasteUpload()
-            ).get();
+            String body = null;
+            try {
+                body = message + "\n\n" + times('-', 50) + "\n" + "Here is my log: " + App.TASKPOOL.submit(new PasteUpload()
+                ).get();
+            } catch (ExecutionException e) {
+                LogManager.logStackTrace("Exception while uploading paste", e);
+                return;
+            }
             Map<String, Object> request = new HashMap<String, Object>();
             request.put("issue", new GithubIssue(title, body));
 
@@ -48,16 +55,16 @@ public final class GithubIssueReporter {
                             .getDataAsString());
                 }
             } catch (IOException e) {
-                e.printStackTrace();
+                LogManager.logStackTrace(e);
             }
         }
     }
 
     private static String times(char c, int times) {
-        String s = "";
+        StringBuilder builder = new StringBuilder();
         for (int i = 0; i < times; i++) {
-            s += c;
+            builder.append(c);
         }
-        return s;
+        return builder.toString();
     }
 }

--- a/src/main/java/com/atlauncher/thread/LoggingThread.java
+++ b/src/main/java/com/atlauncher/thread/LoggingThread.java
@@ -18,18 +18,18 @@
 
 package com.atlauncher.thread;
 
-import com.atlauncher.App;
-import com.atlauncher.data.Constants;
-import com.atlauncher.evnt.LogEvent;
-import com.atlauncher.utils.Timestamper;
-import com.atlauncher.writer.LogEventWriter;
-
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.concurrent.BlockingQueue;
+
+import com.atlauncher.App;
+import com.atlauncher.data.Constants;
+import com.atlauncher.evnt.LogEvent;
+import com.atlauncher.utils.Timestamper;
+import com.atlauncher.writer.LogEventWriter;
 
 public final class LoggingThread extends Thread {
     private final LogEventWriter writer;
@@ -41,12 +41,10 @@ public final class LoggingThread extends Thread {
         this.queue = queue;
         this.setName("ATL-Logging-Thread");
         File log = new File(App.settings.getLogsDir(), filename);
-        if (!log.exists()) {
-            try {
-                log.createNewFile();
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
+        try {
+            log.createNewFile();
+        } catch (IOException e) {
+            e.printStackTrace();
         }
         try {
             this.writer = new LogEventWriter(new FileWriter(log));
@@ -68,15 +66,17 @@ public final class LoggingThread extends Thread {
 
     @Override
     public void run() {
-        try {
-            while (true) {
-                LogEvent next = this.queue.take();
-                if (next != null) {
-                    next.post(this.writer);
-                }
+        while (true) {
+            LogEvent next;
+            try {
+                next = this.queue.take();
+            } catch (InterruptedException ignored) {
+                Thread.currentThread().interrupt();
+                return;
             }
-        } catch (Exception ex) {
-            ex.printStackTrace(System.err);
+            if (next != null) {
+                next.post(this.writer);
+            }
         }
     }
 

--- a/src/main/java/com/atlauncher/thread/PasteUpload.java
+++ b/src/main/java/com/atlauncher/thread/PasteUpload.java
@@ -18,47 +18,83 @@
 
 package com.atlauncher.thread;
 
-import com.atlauncher.App;
-import com.atlauncher.data.Constants;
-
 import java.io.BufferedReader;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.util.concurrent.Callable;
 
+import com.atlauncher.App;
+import com.atlauncher.LogManager;
+import com.atlauncher.data.Constants;
+
 public final class PasteUpload implements Callable<String> {
     @Override
-    public String call() throws Exception {
+    public String call() {
         String log = App.settings.getLog().replace(System.getProperty("line.separator"), "\n");
         String urlParameters = "";
-        urlParameters += "title=" + URLEncoder.encode(Constants.LAUNCHER_NAME + " - Log", "UTF-8") + "&";
-        urlParameters += "language=" + URLEncoder.encode("text", "UTF-8") + "&";
-        urlParameters += "private=" + URLEncoder.encode("1", "UTF-8") + "&";
-        urlParameters += "text=" + URLEncoder.encode(log, "UTF-8");
-        HttpURLConnection conn = (HttpURLConnection) new URL(Constants.PASTE_API_URL).openConnection();
+        try {
+            urlParameters += "title=" + URLEncoder.encode(Constants.LAUNCHER_NAME + " - Log", "UTF-8") + "&";
+            urlParameters += "language=" + URLEncoder.encode("text", "UTF-8") + "&";
+            urlParameters += "private=" + URLEncoder.encode("1", "UTF-8") + "&";
+            urlParameters += "text=" + URLEncoder.encode(log, "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            LogManager.logStackTrace("Unsupported encoding", e);
+            return "Unsupported encoding";
+        }
+        HttpURLConnection conn;
+        try {
+            conn = (HttpURLConnection) new URL(Constants.PASTE_API_URL).openConnection();
+        } catch (MalformedURLException e) {
+            LogManager.logStackTrace("Malformed paste API URL", e);
+            return "Malformed paste API URL";
+        } catch (IOException e) {
+            LogManager.logStackTrace("Failed to connect to paste API", e);
+            return "Failed to connect to paste API";
+        }
         conn.setDoOutput(true);
-        conn.connect();
-        conn.getOutputStream().write(urlParameters.getBytes());
-        conn.getOutputStream().flush();
-        conn.getOutputStream().close();
-
-        String line;
+        try {
+            conn.connect();
+            conn.getOutputStream().write(urlParameters.getBytes());
+            conn.getOutputStream().flush();
+            conn.getOutputStream().close();
+        } catch (IOException e) {
+            LogManager.logStackTrace("Failed to send data to paste API", e);
+            return "Failed to send data to paste API";
+        }
+    
         StringBuilder builder = new StringBuilder();
         InputStream stream;
         try {
             stream = conn.getInputStream();
-        } catch (Exception ex) {
-            ex.printStackTrace(System.err);
+        } catch (IOException e) {
+            LogManager.logStackTrace("Failed to receive response from paste API", e);
             stream = conn.getErrorStream();
+            if (stream == null) {
+                LogManager.error("No error message returned from paste API");
+                return "No error message returned from paste API";
+            }
         }
         BufferedReader reader = new BufferedReader(new InputStreamReader(stream));
-        while ((line = reader.readLine()) != null) {
-            builder.append(line);
+        try {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                builder.append(line);
+            }
+        } catch (IOException e) {
+            LogManager.logStackTrace("Failed to read error data", e);
+        } finally {
+            try {
+                reader.close();
+            } catch (IOException e) {
+                LogManager.logStackTrace("Failed to close error reader", e);
+            }
         }
-        reader.close();
         return builder.toString();
     }
 }

--- a/src/main/java/com/atlauncher/utils/ATLauncherAPIUtils.java
+++ b/src/main/java/com/atlauncher/utils/ATLauncherAPIUtils.java
@@ -17,7 +17,7 @@
  */
 package com.atlauncher.utils;
 
-import com.atlauncher.App;
+import com.atlauncher.LogManager;
 import com.atlauncher.data.Constants;
 import com.atlauncher.data.mojang.OperatingSystem;
 
@@ -42,7 +42,7 @@ public class ATLauncherAPIUtils {
         try {
             Utils.sendAPICall("system-info", request);
         } catch (IOException e) {
-            App.settings.logStackTrace("Error sending in details of system", e);
+            LogManager.logStackTrace("Error sending in details of system", e);
         }
     }
 }

--- a/src/main/java/com/atlauncher/utils/Authentication.java
+++ b/src/main/java/com/atlauncher/utils/Authentication.java
@@ -18,11 +18,10 @@
 package com.atlauncher.utils;
 
 import com.atlauncher.App;
-import com.atlauncher.Gsons;
+import com.atlauncher.LogManager;
 import com.atlauncher.data.Account;
-import com.atlauncher.data.Downloadable;
 import com.atlauncher.data.LoginResponse;
-import com.atlauncher.data.mojang.api.ProfileResponse;
+
 import com.mojang.authlib.Agent;
 import com.mojang.authlib.exceptions.AuthenticationException;
 import com.mojang.authlib.exceptions.AuthenticationUnavailableException;
@@ -49,7 +48,7 @@ public class Authentication {
                 response.setAuth(auth);
             } catch (AuthenticationException e) {
                 response.setErrorMessage(e.getMessage());
-                e.printStackTrace();
+                LogManager.logStackTrace("Authentication failed", e);
             }
         }
 
@@ -84,10 +83,10 @@ public class Authentication {
             } catch (AuthenticationUnavailableException e) {
                 response.setErrorMessage(e.getMessage());
                 response.setOffline();
-                e.printStackTrace();
+                LogManager.logStackTrace("Authentication servers unavailable", e);
             } catch (AuthenticationException e) {
                 response.setErrorMessage(e.getMessage());
-                e.printStackTrace();
+                LogManager.logStackTrace("Authentication failed", e);
             }
         }
 

--- a/src/main/java/com/atlauncher/utils/Base64.java
+++ b/src/main/java/com/atlauncher/utils/Base64.java
@@ -165,6 +165,8 @@
  */
 package com.atlauncher.utils;
 
+import com.atlauncher.LogManager;
+
 public class Base64 {
     /* ******** P U B L I C F I E L D S ******** */
 
@@ -1285,7 +1287,7 @@ public class Base64 {
 
                 } // end try
                 catch (java.io.IOException e) {
-                    e.printStackTrace();
+                    LogManager.logStackTrace(e);
                     // Just return originally-decoded bytes
                 } // end catch
                 finally {

--- a/src/main/java/com/atlauncher/utils/Resources.java
+++ b/src/main/java/com/atlauncher/utils/Resources.java
@@ -168,7 +168,7 @@ public final class Resources {
                 }
             }
         } catch (Exception ex) {
-            App.settings.logStackTrace("Cannot find font " + name, ex);
+            LogManager.logStackTrace("Cannot find font " + name, ex);
             return new Font("Sans-Serif", Font.PLAIN, 0);
         }
     }

--- a/src/main/java/com/atlauncher/utils/Utils.java
+++ b/src/main/java/com/atlauncher/utils/Utils.java
@@ -122,7 +122,7 @@ public class Utils {
      * @return the icon image
      */
     public static ImageIcon getIconImage(String path) {
-        File themeFile = App.settings.getThemeFile();
+        File themeFile = App.settings == null ? null : App.settings.getThemeFile();
 
         if (themeFile != null) {
 
@@ -246,7 +246,7 @@ public class Utils {
             name += ".png";
         }
 
-        File themeFile = App.settings.getThemeFile();
+        File themeFile = App.settings == null ? null : App.settings.getThemeFile();
 
         if (themeFile != null) {
     

--- a/src/main/java/com/atlauncher/utils/Utils.java
+++ b/src/main/java/com/atlauncher/utils/Utils.java
@@ -17,6 +17,23 @@
  */
 package com.atlauncher.utils;
 
+import com.atlauncher.App;
+import com.atlauncher.Gsons;
+import com.atlauncher.LogManager;
+import com.atlauncher.data.Constants;
+import com.atlauncher.data.mojang.ExtractRule;
+import com.atlauncher.data.mojang.OperatingSystem;
+import com.atlauncher.data.openmods.OpenEyeReportResponse;
+import com.atlauncher.evnt.LogEvent.LogType;
+import org.tukaani.xz.XZInputStream;
+
+import javax.crypto.BadPaddingException;
+import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.spec.SecretKeySpec;
+import javax.imageio.ImageIO;
+import javax.net.ssl.HttpsURLConnection;
+import javax.swing.ImageIcon;
 import java.awt.Desktop;
 import java.awt.Dimension;
 import java.awt.Font;
@@ -64,7 +81,6 @@ import java.security.InvalidKeyException;
 import java.security.Key;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Deque;
 import java.util.Enumeration;
@@ -79,25 +95,6 @@ import java.util.regex.Pattern;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import java.util.zip.ZipOutputStream;
-
-import javax.crypto.BadPaddingException;
-import javax.crypto.Cipher;
-import javax.crypto.IllegalBlockSizeException;
-import javax.crypto.spec.SecretKeySpec;
-import javax.imageio.ImageIO;
-import javax.net.ssl.HttpsURLConnection;
-import javax.swing.ImageIcon;
-
-import org.tukaani.xz.XZInputStream;
-
-import com.atlauncher.App;
-import com.atlauncher.Gsons;
-import com.atlauncher.LogManager;
-import com.atlauncher.data.Constants;
-import com.atlauncher.data.mojang.ExtractRule;
-import com.atlauncher.data.mojang.OperatingSystem;
-import com.atlauncher.data.openmods.OpenEyeReportResponse;
-import com.atlauncher.evnt.LogEvent.LogType;
 
 public class Utils {
     public static String error(Throwable t) {
@@ -286,7 +283,7 @@ public class Utils {
             try {
                 Desktop.getDesktop().open(file);
             } catch (Exception e) {
-                App.settings.logStackTrace(e);
+                LogManager.logStackTrace(e);
             }
         }
     }
@@ -302,7 +299,7 @@ public class Utils {
                 Desktop.getDesktop().browse(new URI(URL));
             } catch (Exception e) {
                 LogManager.error("Failed to open link " + URL + " in browser!");
-                App.settings.logStackTrace(e);
+                LogManager.logStackTrace(e);
             }
         }
     }
@@ -318,7 +315,7 @@ public class Utils {
                 Desktop.getDesktop().browse(URL.toURI());
             } catch (Exception e) {
                 LogManager.error("Failed to open link " + URL + " in browser!");
-                App.settings.logStackTrace(e);
+                LogManager.logStackTrace(e);
             }
         }
     }
@@ -454,15 +451,15 @@ public class Utils {
                 ram = 1024;
             }
         } catch (SecurityException e) {
-            App.settings.logStackTrace(e);
+            LogManager.logStackTrace(e);
         } catch (NoSuchMethodException e) {
-            App.settings.logStackTrace(e);
+            LogManager.logStackTrace(e);
         } catch (IllegalArgumentException e) {
-            App.settings.logStackTrace(e);
+            LogManager.logStackTrace(e);
         } catch (IllegalAccessException e) {
-            App.settings.logStackTrace(e);
+            LogManager.logStackTrace(e);
         } catch (InvocationTargetException e) {
-            App.settings.logStackTrace(e);
+            LogManager.logStackTrace(e);
         }
         return ram;
     }
@@ -556,7 +553,7 @@ public class Utils {
             writer.close();
             reader.close();
         } catch (IOException e1) {
-            App.settings.logStackTrace(e1);
+            LogManager.logStackTrace(e1);
         }
         return result;
     }
@@ -595,11 +592,11 @@ public class Utils {
                 fis.close();
             }
         } catch (NoSuchAlgorithmException e) {
-            App.settings.logStackTrace(e);
+            LogManager.logStackTrace(e);
         } catch (FileNotFoundException e) {
-            App.settings.logStackTrace(e);
+            LogManager.logStackTrace(e);
         } catch (IOException e) {
-            App.settings.logStackTrace(e);
+            LogManager.logStackTrace(e);
         }
         return sb.toString();
     }
@@ -638,11 +635,11 @@ public class Utils {
                 fis.close();
             }
         } catch (NoSuchAlgorithmException e) {
-            App.settings.logStackTrace(e);
+            LogManager.logStackTrace(e);
         } catch (FileNotFoundException e) {
-            App.settings.logStackTrace(e);
+            LogManager.logStackTrace(e);
         } catch (IOException e) {
-            App.settings.logStackTrace(e);
+            LogManager.logStackTrace(e);
         }
         return sb.toString();
     }
@@ -670,9 +667,9 @@ public class Utils {
                 sb.append(Integer.toString((mdbytes[i] & 0xff) + 0x100, 16).substring(1));
             }
         } catch (NoSuchAlgorithmException e) {
-            App.settings.logStackTrace(e);
+            LogManager.logStackTrace(e);
         } catch (IOException e) {
-            App.settings.logStackTrace(e);
+            LogManager.logStackTrace(e);
         }
         return sb.toString();
     }
@@ -734,7 +731,7 @@ public class Utils {
         try {
             to.createNewFile();
         } catch (IOException e) {
-            App.settings.logStackTrace(e);
+            LogManager.logStackTrace(e);
             return false;
         }
 
@@ -746,7 +743,7 @@ public class Utils {
             destination = new FileOutputStream(to).getChannel();
             destination.transferFrom(source, 0, source.size());
         } catch (IOException e) {
-            App.settings.logStackTrace(e);
+            LogManager.logStackTrace(e);
             return false;
         } finally {
             try {
@@ -757,7 +754,7 @@ public class Utils {
                     destination.close();
                 }
             } catch (IOException e) {
-                App.settings.logStackTrace(e);
+                LogManager.logStackTrace(e);
                 return false;
             }
         }
@@ -859,7 +856,7 @@ public class Utils {
                 out.close();
             }
         } catch (IOException e) {
-            App.settings.logStackTrace(e);
+            LogManager.logStackTrace(e);
             return false;
         }
         return true;
@@ -921,7 +918,7 @@ public class Utils {
             }
             zipFile.close();
         } catch (IOException e) {
-            App.settings.logStackTrace(e);
+            LogManager.logStackTrace(e);
         }
     }
 
@@ -1086,7 +1083,7 @@ public class Utils {
                 }
             }
         } catch (IOException e) {
-            App.settings.logStackTrace(e);
+            LogManager.logStackTrace(e);
         }
     }
 
@@ -1140,7 +1137,7 @@ public class Utils {
             byte[] encVal = c.doFinal(Data.getBytes());
             encryptedValue = Base64.encodeBytes(encVal);
         } catch (Exception e) {
-            App.settings.logStackTrace(e);
+            LogManager.logStackTrace(e);
         }
         return encryptedValue;
     }
@@ -1168,7 +1165,7 @@ public class Utils {
         } catch (IllegalBlockSizeException e) {
             return Utils.decryptOld(encryptedData);
         } catch (Exception e) {
-            App.settings.logStackTrace(e);
+            LogManager.logStackTrace(e);
         }
         return decryptedValue;
     }
@@ -1368,13 +1365,13 @@ public class Utils {
             }
             return found;
         } catch (IOException e) {
-            App.settings.logStackTrace(e);
+            LogManager.logStackTrace(e);
         } finally {
             if (input != null) {
                 try {
                     input.close();
                 } catch (IOException e) {
-                    App.settings.logStackTrace("Unable to close input stream", e);
+                    LogManager.logStackTrace("Unable to close input stream", e);
                 }
             }
         }
@@ -1459,7 +1456,7 @@ public class Utils {
                     br.close();
                 }
             } catch (IOException e) {
-                App.settings.logStackTrace(e);
+                LogManager.logStackTrace(e);
             }
 
             LogManager.warn("Cannot get Java version from the ouput of \"" + javaCommand + "\" -version");
@@ -1603,7 +1600,7 @@ public class Utils {
             writer.flush();
             writer.close();
         } catch (IOException e) {
-            App.settings.logStackTrace(e);
+            LogManager.logStackTrace(e);
             return null; // Report not sent
         }
 
@@ -1619,7 +1616,7 @@ public class Utils {
                 response.append('\r');
             }
         } catch (IOException e) {
-            App.settings.logStackTrace(e);
+            LogManager.logStackTrace(e);
             return null; // Report sent, but no response
         } finally {
             try {
@@ -1627,7 +1624,7 @@ public class Utils {
                     reader.close();
                 }
             } catch (IOException e) {
-                App.settings.logStackTrace(e);
+                LogManager.logStackTrace(e);
             }
         }
 
@@ -1660,14 +1657,14 @@ public class Utils {
             }
             contents = sb.toString();
         } catch (IOException e) {
-            App.settings.logStackTrace(e);
+            LogManager.logStackTrace(e);
         } finally {
             try {
                 if (br != null) {
                     br.close();
                 }
             } catch (IOException e) {
-                App.settings.logStackTrace(e);
+                LogManager.logStackTrace(e);
             }
         }
         return contents;
@@ -1797,7 +1794,7 @@ public class Utils {
             pingStats = response.toString();
 
         } catch (IOException e) {
-            App.settings.logStackTrace("IOException while running ping on host " + host, e);
+            LogManager.logStackTrace("IOException while running ping on host " + host, e);
         }
 
         return pingStats;
@@ -1829,7 +1826,7 @@ public class Utils {
             route = response.toString();
 
         } catch (IOException e) {
-            App.settings.logStackTrace("IOException while running traceRoute on host " + host, e);
+            LogManager.logStackTrace("IOException while running traceRoute on host " + host, e);
         }
 
         return route;
@@ -1927,13 +1924,13 @@ public class Utils {
             bytes = new byte[(int) f.length()];
             f.read(bytes);
         } catch (IOException e) {
-            App.settings.logStackTrace(e);
+            LogManager.logStackTrace(e);
         } finally {
             if (f != null) {
                 try {
                     f.close();
                 } catch (IOException e) {
-                    App.settings.logStackTrace(e);
+                    LogManager.logStackTrace(e);
                 }
             }
         }
@@ -1962,7 +1959,7 @@ public class Utils {
             }
 
         } catch (IOException e) {
-            App.settings.logStackTrace(e);
+            LogManager.logStackTrace(e);
         } finally {
             try {
                 if (fis != null) {
@@ -1978,7 +1975,7 @@ public class Utils {
                     xzis.close();
                 }
             } catch (IOException e) {
-                App.settings.logStackTrace(e);
+                LogManager.logStackTrace(e);
             }
         }
     }
@@ -2021,7 +2018,7 @@ public class Utils {
             jos.close();
             jarBytes.close();
         } catch (IOException e) {
-            App.settings.logStackTrace(e);
+            LogManager.logStackTrace(e);
         }
     }
 
@@ -2063,7 +2060,7 @@ public class Utils {
                 }
             }
         } catch (Exception e) {
-            App.settings.logStackTrace(e);
+            LogManager.logStackTrace(e);
         } finally {
             returnStr = (returnStr == null ? "NotARandomKeyYes" : returnStr);
         }
@@ -2099,7 +2096,7 @@ public class Utils {
             App.settings.getClass().forName("com.mojang.authlib.yggdrasil.YggdrasilAuthenticationService");
             App.settings.getClass().forName("com.mojang.authlib.yggdrasil.YggdrasilUserAuthentication");
         } catch (ClassNotFoundException e) {
-            App.settings.logStackTrace(e);
+            LogManager.logStackTrace(e);
             return false;
         }
 

--- a/src/main/java/com/atlauncher/workers/InstanceInstaller.java
+++ b/src/main/java/com/atlauncher/workers/InstanceInstaller.java
@@ -17,6 +17,25 @@
  */
 package com.atlauncher.workers;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.FileReader;
+import java.io.FilenameFilter;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.jar.JarEntry;
+import java.util.jar.JarInputStream;
+import java.util.jar.JarOutputStream;
+
+import javax.swing.SwingWorker;
+
 import com.atlauncher.App;
 import com.atlauncher.Gsons;
 import com.atlauncher.LogManager;
@@ -45,29 +64,12 @@ import com.atlauncher.data.mojang.MojangConstants;
 import com.atlauncher.data.mojang.MojangDownloads;
 import com.atlauncher.gui.dialogs.ModsChooser;
 import com.atlauncher.utils.Utils;
+
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonIOException;
 import com.google.gson.JsonParseException;
 import com.google.gson.JsonSyntaxException;
-
-import javax.swing.SwingWorker;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.FileReader;
-import java.io.FilenameFilter;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.jar.JarEntry;
-import java.util.jar.JarInputStream;
-import java.util.jar.JarOutputStream;
 
 public class InstanceInstaller extends SwingWorker<Boolean, Void> {
 
@@ -1514,7 +1516,7 @@ public class InstanceInstaller extends SwingWorker<Boolean, Void> {
                 shareCodeData = response.getDataAsString();
             }
         } catch (IOException e) {
-            e.printStackTrace();
+            LogManager.logStackTrace("API call failed", e);
         }
 
         return shareCodeData;

--- a/src/main/java/com/atlauncher/workers/InstanceInstaller.java
+++ b/src/main/java/com/atlauncher/workers/InstanceInstaller.java
@@ -763,11 +763,11 @@ public class InstanceInstaller extends SwingWorker<Boolean, Void> {
                 }
             }
         } catch (JsonSyntaxException e) {
-            App.settings.logStackTrace(e);
+            LogManager.logStackTrace(e);
         } catch (JsonIOException e) {
-            App.settings.logStackTrace(e);
+            LogManager.logStackTrace(e);
         } catch (FileNotFoundException e) {
-            App.settings.logStackTrace(e);
+            LogManager.logStackTrace(e);
         }
 
         return downloads;
@@ -907,7 +907,7 @@ public class InstanceInstaller extends SwingWorker<Boolean, Void> {
             inputFile.delete();
             outputTmpFile.renameTo(inputFile);
         } catch (IOException e) {
-            App.settings.logStackTrace(e);
+            LogManager.logStackTrace(e);
         }
     }
 
@@ -1334,7 +1334,7 @@ public class InstanceInstaller extends SwingWorker<Boolean, Void> {
             this.jsonVersion = Gsons.DEFAULT.fromJson(this.pack.getJSON(version.getVersion()), Version.class);
             return installUsingJSON();
         } catch (JsonParseException e) {
-            App.settings.logStackTrace("Couldn't parse JSON of pack!", e);
+            LogManager.logStackTrace("Couldn't parse JSON of pack!", e);
         }
 
         return false;

--- a/src/main/java/io/github/asyncronous/toast/Toaster.java
+++ b/src/main/java/io/github/asyncronous/toast/Toaster.java
@@ -1,16 +1,20 @@
 package io.github.asyncronous.toast;
 
-import io.github.asyncronous.toast.ui.ToastWindow;
+import java.awt.Color;
+import java.awt.Font;
+import java.awt.GraphicsEnvironment;
+import java.awt.Image;
+import java.io.IOException;
+import java.io.InputStream;
 
 import javax.imageio.ImageIO;
 import javax.swing.Icon;
 import javax.swing.ImageIcon;
 import javax.swing.UIManager;
-import java.awt.Color;
-import java.awt.Font;
-import java.awt.GraphicsEnvironment;
-import java.awt.Image;
-import java.io.InputStream;
+
+import com.atlauncher.LogManager;
+
+import io.github.asyncronous.toast.ui.ToastWindow;
 
 /**
  * Static class to allow easier use of toaster notifications
@@ -124,16 +128,16 @@ public final class Toaster {
     }
 
     private Image createImage(String name) {
+        InputStream stream = Toaster.class.getResourceAsStream("/assets/toast/icons/" + name + ".png");
+
+        if (stream == null) {
+            throw new NullPointerException("Stream == null");
+        }
+
         try {
-            InputStream stream = Toaster.class.getResourceAsStream("/assets/toast/icons/" + name + ".png");
-
-            if (stream == null) {
-                throw new NullPointerException("Stream == null");
-            }
-
             return ImageIO.read(stream);
-        } catch (Exception ex) {
-            ex.printStackTrace(System.err);
+        } catch (IOException ex) {
+            LogManager.logStackTrace("Failed to load Toaster image", ex);
             return null;
         }
     }


### PR DESCRIPTION
* Moved `logStackTrace` from `Settings` to `LogManager` and made it `static`
* Replaced most uses of `Throwable.printStackTrace` with `LogManager.logStackTrace` (except for some in the logging and console internals, which really shouldn't produce more log messages if logging fails)
* Improved some exception handlers - replaced some Pokémon (catch 'em all) exception handlers with specific exceptions, fixed `InterruptedException` handling, added `finally` blocks for some streams
* Fixed a Java 6 compatibility issue in `LegacyMCLauncher`
* Fixed a NPE in `EditModsDialog`

The changes related to `logStackTrace` affected a bunch of files, you may want to look at the commits individually so you can see what's important and what is just a rename.