### PR TITLE
Fix Crash at Startup when getting minorVersion from windows default jre

### DIFF
--- a/src/main/java/com/atlauncher/utils/OS.java
+++ b/src/main/java/com/atlauncher/utils/OS.java
@@ -217,7 +217,7 @@ public enum OS {
 
         // get newest Java 8 64 bit if installed
         Optional<JavaInfo> java864bit = installedJavas.stream()
-                .sorted(Comparator.comparingInt((JavaInfo javaInfo) -> javaInfo.minorVersion).reversed())
+                .sorted(Comparator.comparingInt((JavaInfo javaInfo) -> javaInfo.minorVersion != null ? javaInfo.minorVersion : 0).reversed())
                 .filter(javaInfo -> javaInfo.majorVersion == 8 && javaInfo.is64bits).findFirst();
         if (java864bit.isPresent()) {
             return java864bit.get().rootPath;


### PR DESCRIPTION
### Description of the Change

Prevents a null pointer exception by returning 0 when minorVersion is null.

### Testing

I have tested the app and it was able to get past the crash

### Related Issues

n/a
