### PR TITLE
Fix for #356

### DIFF
--- a/src/main/java/com/atlauncher/data/loaders/forge/Processor.java
+++ b/src/main/java/com/atlauncher/data/loaders/forge/Processor.java
@@ -128,17 +128,21 @@ public class Processor {
                 }
 
                 if (value.charAt(0) == File.separatorChar) {
-                    File localFile = new File(extractedDir, value);
-                    LogManager.debug("Got argument with local file of " + localFile.getAbsolutePath());
+                    if(value.toLowerCase().contains(App.settings.getGameLibrariesDir().toString().toLowerCase())){
+                        args.add(value);
+                    } else {
+                        File localFile = new File(extractedDir, value);
+                        LogManager.debug("Got argument with local file of " + localFile.getAbsolutePath());
 
-                    if (!localFile.exists() || !localFile.isFile()) {
-                        LogManager.error("Failed to process argument with value of " + value + " as the local file "
-                                + localFile.getAbsolutePath() + " doesn't exist");
-                        instanceInstaller.cancel(true);
-                        return;
+                        if (!localFile.exists() || !localFile.isFile()) {
+                            LogManager.error("Failed to process argument with value of " + value + " as the local file "
+                                    + localFile.getAbsolutePath() + " doesn't exist");
+                            instanceInstaller.cancel(true);
+                            return;
+                        }
+
+                        args.add(localFile.getAbsolutePath());
                     }
-
-                    args.add(localFile.getAbsolutePath());
                 } else {
                     args.add(value);
                 }


### PR DESCRIPTION
### Description of the Change

This section of the code is attempting to determine if the specified file path is absolute or relative. It is doing so by checking the first character. In linux, however, this is not sufficient. Absolute paths can be `/home/dallas/ATLauncher/whatever.json`, for example. 

Through testing, I determined that the only absolute paths passed to this function are those of ATLauncher's root level libraries folder. Thus, if the incoming path contains the libraries folder, it is clearly an absolute path. Add it to the args directly instead of prefixing it.

### Testing

Tested this on linux and was able to successfully install Vanilla with Forge.

### Related Issues

Fixes #356 
