### PR TITLE
add: compile in Docker container

### DIFF
--- a/docker-gradle-build.sh
+++ b/docker-gradle-build.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+docker run -it -v $(pwd):/app --workdir /app openjdk:11-jdk-slim /app/gradlew build


### PR DESCRIPTION
### Description of the Change

If I'm not a Java user, I'm not going to install java dev stack. However, I might have Docker installed and removing isolated Docker image is way simpler than removing JDK + Gradle deps.

Also it provides a way for me as a dev to report an error quicker in a reproducible manner because if it fails for me with the same openJDK image, it'll fail for anyone else and the problems that can be encountered are narrowed to e.g. permission errors, chown/chmod errors and connectivity errors.

Another pro side: With one command (if you have Docker available) you can quickly provide released .exe/.jar via CI if you use the GitHub API for uploading assets to a release and you are safely separated from the issues e.g. CircleCI might cause :smile: 

### Testing

    ./docker-gradle-build.sh
