### PR TITLE
Add Feral Gamemode integration

### DIFF
--- a/src/main/java/com/atlauncher/data/Settings.java
+++ b/src/main/java/com/atlauncher/data/Settings.java
@@ -116,6 +116,7 @@ public class Settings {
     private boolean enableConsole; // If to show the console by default
     private boolean enableTrayIcon; // If to enable tray icon
     private boolean enableDiscordIntegration; // If to enable Discord integration
+    private boolean enableFeralGamemode; // If to enable Feral Gamemode
     private boolean enableLeaderboards; // If to enable the leaderboards
     private boolean enableLogs; // If to enable logs
     private boolean enableAnalytics; // If to enable analytics
@@ -630,6 +631,8 @@ public class Settings {
             this.enableTrayIcon = Boolean.parseBoolean(properties.getProperty("enabletrayicon", "true"));
             this.enableDiscordIntegration = Boolean
                     .parseBoolean(properties.getProperty("enablediscordintegration", "true"));
+            this.enableFeralGamemode = Boolean
+                    .parseBoolean(properties.getProperty("enableferalgamemode", Boolean.toString(Utils.executableInPath("gamemoderun"))));
 
             String lang = properties.getProperty("language", "English");
             Language.setLanguage(lang);
@@ -806,6 +809,9 @@ public class Settings {
             this.enableDiscordIntegration = Boolean
                     .parseBoolean(properties.getProperty("enablediscordintegration", "true"));
 
+            this.enableFeralGamemode = Boolean
+                    .parseBoolean(properties.getProperty("enableferalgamemode", "true"));
+
             this.enableLeaderboards = Boolean.parseBoolean(properties.getProperty("enableleaderboards", "false"));
 
             this.enableLogs = Boolean.parseBoolean(properties.getProperty("enablelogs", "true"));
@@ -922,6 +928,7 @@ public class Settings {
             properties.setProperty("enableconsole", (this.enableConsole) ? "true" : "false");
             properties.setProperty("enabletrayicon", (this.enableTrayIcon) ? "true" : "false");
             properties.setProperty("enablediscordintegration", (this.enableDiscordIntegration) ? "true" : "false");
+            properties.setProperty("enableferalgamemode", (this.enableFeralGamemode) ? "true" : "false");
             properties.setProperty("enableleaderboards", (this.enableLeaderboards) ? "true" : "false");
             properties.setProperty("enablelogs", (this.enableLogs) ? "true" : "false");
             properties.setProperty("enableanalytics", (this.enableAnalytics) ? "true" : "false");
@@ -2176,6 +2183,10 @@ public class Settings {
         return this.enableDiscordIntegration;
     }
 
+    public boolean enableFeralGamemode() {
+        return this.enableFeralGamemode;
+    }
+
     public void setEnableConsole(boolean enableConsole) {
         this.enableConsole = enableConsole;
     }
@@ -2194,6 +2205,10 @@ public class Settings {
 
     public void setEnableDiscordIntegration(boolean enableDiscordIntegration) {
         this.enableDiscordIntegration = enableDiscordIntegration;
+    }
+
+    public void setEnableFeralGameMode(boolean enableFeralGamemode) {
+        this.enableFeralGamemode = enableFeralGamemode;
     }
 
     public boolean enableLeaderboards() {

--- a/src/main/java/com/atlauncher/gui/tabs/settings/GeneralSettingsTab.java
+++ b/src/main/java/com/atlauncher/gui/tabs/settings/GeneralSettingsTab.java
@@ -58,6 +58,8 @@ public class GeneralSettingsTab extends AbstractSettingsTab {
     private JCheckBox enableTrayIcon;
     private JLabelWithHover enableDiscordIntegrationLabel;
     private JCheckBox enableDiscordIntegration;
+    private JLabelWithHover enableFeralGamemodeLabel;
+    private JCheckBox enableFeralGamemode;
     private JLabelWithHover enablePackTagsLabel;
     private JCheckBox enablePackTags;
 
@@ -238,12 +240,47 @@ public class GeneralSettingsTab extends AbstractSettingsTab {
         }
         add(enableDiscordIntegration, gbc);
 
+        // Enable Feral Gamemode
+        if (OS.isLinux()) {
+            boolean gameModeExistsInPath = Utils.executableInPath("gamemoderun");
+
+            gbc.gridx = 0;
+            gbc.gridy++;
+            gbc.insets = LABEL_INSETS;
+            gbc.anchor = GridBagConstraints.BASELINE_TRAILING;
+            enableFeralGamemodeLabel = new JLabelWithHover(GetText.tr("Enable Feral Gamemode") + "?", HELP_ICON,
+                    GetText.tr("This will enable Feral Gamemode for packs launched."));
+            add(enableFeralGamemodeLabel, gbc);
+
+            gbc.gridx++;
+            gbc.insets = FIELD_INSETS;
+            gbc.anchor = GridBagConstraints.BASELINE_LEADING;
+            enableFeralGamemode = new JCheckBox();
+            if (App.settings.enableFeralGamemode()) {
+                enableFeralGamemode.setSelected(true);
+            }
+
+            if (! gameModeExistsInPath) {
+                enableFeralGamemodeLabel.setToolTipText(
+                    GetText.tr("This will enable Feral Gamemode for packs launched (disabled because gamemoderun not found in PATH, please install Feral Gamemode or add it to your PATH).")
+                );
+                enableFeralGamemodeLabel.setEnabled(false);
+
+                enableFeralGamemode.setEnabled(false);
+                enableFeralGamemode.setSelected(false);
+            }
+            add(enableFeralGamemode, gbc);
+        }
+
+        // Pack tags
+
         gbc.gridx = 0;
         gbc.gridy++;
         gbc.insets = LABEL_INSETS;
         gbc.anchor = GridBagConstraints.BASELINE_TRAILING;
         enablePackTagsLabel = new JLabelWithHover(GetText.tr("Enable Pack Tags"), HELP_ICON,
-                GetText.tr("Pack tags shows you if a pack is public, semi public or private"));
+            GetText.tr("Pack tags shows you if a pack is public, semi public or private")
+        );
         add(enablePackTagsLabel, gbc);
 
         gbc.gridx++;
@@ -275,6 +312,13 @@ public class GeneralSettingsTab extends AbstractSettingsTab {
         App.settings.setEnableConsole(enableConsole.isSelected());
         App.settings.setEnableTrayIcon(enableTrayIcon.isSelected());
         App.settings.setEnableDiscordIntegration(enableDiscordIntegration.isSelected());
+
+        if (OS.isLinux()) {
+            App.settings.setEnableFeralGameMode(enableFeralGamemode.isSelected());
+        } else {
+            App.settings.setEnableFeralGameMode(false);
+        }
+
         App.settings.setPackTags(enablePackTags.isSelected());
     }
 

--- a/src/main/java/com/atlauncher/mclauncher/MCLauncher.java
+++ b/src/main/java/com/atlauncher/mclauncher/MCLauncher.java
@@ -42,6 +42,7 @@ import com.atlauncher.data.minecraft.VersionManifestVersion;
 import com.atlauncher.network.ErrorReporting;
 import com.atlauncher.utils.Java;
 import com.atlauncher.utils.OS;
+import com.atlauncher.utils.Utils;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.mojang.authlib.properties.PropertyMap;
@@ -376,6 +377,10 @@ public class MCLauncher {
         }
 
         List<String> arguments = new ArrayList<>();
+
+        if (OS.isLinux() && App.settings.enableFeralGamemode() && Utils.executableInPath("gamemoderun")) {
+          arguments.add("gamemoderun");
+        }
 
         String path = javaPath + File.separator + "bin" + File.separator + "java";
         if (OS.isWindows()) {

--- a/src/main/java/com/atlauncher/utils/Utils.java
+++ b/src/main/java/com/atlauncher/utils/Utils.java
@@ -50,6 +50,8 @@ import java.net.URLConnection;
 import java.net.URLEncoder;
 import java.nio.channels.FileChannel;
 import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.security.InvalidKeyException;
 import java.security.Key;
@@ -1646,5 +1648,11 @@ public class Utils {
         }
 
         return null;
+    }
+
+    public static boolean executableInPath(String executableName) {
+          return java.util.stream.Stream.of(System.getenv("PATH").split(java.util.regex.Pattern.quote(File.pathSeparator)))
+            .map(Paths::get)
+            .anyMatch(path -> Files.exists(path.resolve(executableName)) && Files.isExecutable(path.resolve(executableName)));
     }
 }


### PR DESCRIPTION
# Description of the Change

Adds support for launching the Minecraft mod pack instances using Feral Gamemode.

https://github.com/FeralInteractive/gamemode

### Testing

#### Gamemode not installed
![image](https://user-images.githubusercontent.com/1176328/68705357-d7f26e00-0585-11ea-8985-901186427361.png)

#### Gamemode installed
![image](https://user-images.githubusercontent.com/1176328/68705447-01ab9500-0586-11ea-9412-026c308155a5.png)

#### When run an instance is launched with Gamemode enabled
![image](https://user-images.githubusercontent.com/1176328/68705579-3881ab00-0586-11ea-8a16-ea2de054970b.png)

#### When an instance is launched with Gamemode disabled
![image](https://user-images.githubusercontent.com/1176328/68705675-6535c280-0586-11ea-91a4-55f5c5899d94.png)

#### Windows

##### Settings window

<img width="491" alt="atlauncher-settings-windows" src="https://user-images.githubusercontent.com/1176328/68752700-a916df00-05fb-11ea-84d7-f0e5d33fe029.png">

##### Launch log

<img width="916" alt="atlauncher-launch-log" src="https://user-images.githubusercontent.com/1176328/68752699-a87e4880-05fb-11ea-9c2d-123877b53fbe.png">

### Related Issues

None this is an enhancement for when running Minecraft under Linux.
