### PR TITLE
Allow build version suffices

### DIFF
--- a/src/main/java/com/atlauncher/utils/Java.java
+++ b/src/main/java/com/atlauncher/utils/Java.java
@@ -116,7 +116,7 @@ public class Java {
      * @return the parsed build number
      */
     public static int parseJavaBuildVersion(String version) {
-        Matcher m = Pattern.compile(".*[_\\.]([0-9]+)").matcher(version);
+        Matcher m = Pattern.compile(".*[_\\.]([0-9]+).*").matcher(version);
 
         if (m.find()) {
             return Integer.parseInt(m.group(1));


### PR DESCRIPTION
### Description of the Change

Change Java Build Version parsing to accept Java versions that include suffixes after the build number.

This _does_ happen in the wild; my obscure distribution of Linux builds OpenJDK from source, and reports this version:

```
grissess@ceres ATLauncher $ java -version
openjdk version "1.8.0_u212-Exherbo"
OpenJDK Runtime Environment (build 1.8.0_u212-Exherbo-b04)
OpenJDK 64-Bit Server VM (build 25.u212-b04, mixed mode)
```

The suffix `-Exherbo` appears to be causing the matching regular expression to fail.

### Testing

Unfortunately, no testing for a change this trivial; I'm at the mercy of time to set up a build environment proper. If anyone has desire and some support, I'll see if it can't be done.

### Related Issues

(None known so far.)
