### PR TITLE
GH-392 Fixes to FTB pack browser

### DIFF
--- a/src/main/java/com/atlauncher/gui/card/FTBPackCard.java
+++ b/src/main/java/com/atlauncher/gui/card/FTBPackCard.java
@@ -21,6 +21,7 @@ import java.awt.BorderLayout;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
 import java.awt.Window;
+import java.util.Locale;
 
 import javax.swing.BorderFactory;
 import javax.swing.JButton;
@@ -77,7 +78,7 @@ public final class FTBPackCard extends JPanel {
         });
 
         viewButton.addActionListener(e -> OS.openWebBrowser(String.format("https://feed-the-beast.com/modpack/%s",
-                pack.name.toLowerCase().replaceAll("[^A-Za-z0-9]", "_"))));
+                getPackSlug(pack))));
 
         add(summaryPanel, BorderLayout.CENTER);
         add(buttonsPanel, BorderLayout.SOUTH);
@@ -85,5 +86,13 @@ public final class FTBPackCard extends JPanel {
         TitledBorder border = new TitledBorder(null, pack.name, TitledBorder.DEFAULT_JUSTIFICATION,
                 TitledBorder.DEFAULT_POSITION, App.THEME.getBoldFont().deriveFont(12f));
         setBorder(border);
+    }
+
+    private static String getPackSlug(final ModpacksChPackManifest pack) {
+        return pack.name
+            .replace("+", " Plus")
+            .toLowerCase(Locale.ROOT)
+            .replaceAll("\\W", "_")
+            .replaceAll("_{2,}", "_");
     }
 }

--- a/src/main/java/com/atlauncher/gui/card/FTBPackCard.java
+++ b/src/main/java/com/atlauncher/gui/card/FTBPackCard.java
@@ -77,6 +77,12 @@ public final class FTBPackCard extends JPanel {
             ImportPackUtils.loadModpacksChPack(parent, pack.id);
         });
 
+        // The Feed The Beast website only displays modpacks with the 'FTB'
+        // tag present, so we should disable the view button for packs without.
+        if (pack.tags.stream().map(tag -> tag.name).noneMatch("FTB"::equals)) {
+            viewButton.setEnabled(false);
+        }
+
         viewButton.addActionListener(e -> OS.openWebBrowser(String.format("https://feed-the-beast.com/modpack/%s",
                 getPackSlug(pack))));
 


### PR DESCRIPTION
## Improve pack slug generation code

This more closely follows how FTB themselves generate the slug, and
importantly handles all FTB packs now - FTB Vanilla+ being the only
pack not working previously.

Implementation based off https://git.sr.ht/~jmansfield/ftbweb/tree/7d02591e2c2d4f3e362cf9d00879dcfd3835dd97/item/internal/config/crawler.go#L54-68

## Disable view button for none-FTB packs from modpacks.ch

The Feed The Beast website only displays modpacks with the 'FTB'
tag present, so we should disable the view button for packs without.
