### PR TITLE
Add One Dark Theme

### DIFF
--- a/src/main/java/com/atlauncher/gui/tabs/settings/GeneralSettingsTab.java
+++ b/src/main/java/com/atlauncher/gui/tabs/settings/GeneralSettingsTab.java
@@ -121,6 +121,7 @@ public class GeneralSettingsTab extends AbstractSettingsTab {
         theme.addItem(new ComboItem<>("com.atlauncher.themes.ArcOrange", "Arc Orange"));
         theme.addItem(new ComboItem<>("com.atlauncher.themes.CyanLight", "Cyan Light"));
         theme.addItem(new ComboItem<>("com.atlauncher.themes.HighTechDarkness", "High Tech Darkness"));
+        theme.addItem(new ComboItem<>("com.atlauncher.themes.OneDark", "One Dark"));
 
         for (int i = 0; i < theme.getItemCount(); i++) {
             ComboItem<String> item = theme.getItemAt(i);

--- a/src/main/java/com/atlauncher/themes/OneDark.java
+++ b/src/main/java/com/atlauncher/themes/OneDark.java
@@ -1,0 +1,42 @@
+/*
+ * ATLauncher - https://github.com/ATLauncher/ATLauncher
+ * Copyright (C) 2013-2021 ATLauncher
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.atlauncher.themes;
+
+@SuppressWarnings("serial")
+public class OneDark extends Dark {
+    public static boolean install() {
+        instance = new OneDark();
+
+        return install(instance);
+    }
+
+    @Override
+    public String getName() {
+        return "One Dark";
+    }
+
+    @Override
+    public String getDescription() {
+        return "One Dark by TecCheck";
+    }
+
+    @Override
+    public boolean isIntelliJTheme() {
+        return true;
+    }
+}

--- a/src/main/resources/com/atlauncher/themes/OneDark.properties
+++ b/src/main/resources/com/atlauncher/themes/OneDark.properties
@@ -1,0 +1,158 @@
+# suppress inspection "UnusedProperty" for whole file
+#
+# ATLauncher - https://github.com/ATLauncher/ATLauncher
+# Copyright (C) 2013-2020 ATLauncher
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+# This inherits from
+# ./Dark.properties
+# ./ATLauncherLaf.properties
+# https://raw.githubusercontent.com/JFormDesigner/FlatLaf/master/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatDarkLaf.properties
+# https://raw.githubusercontent.com/JFormDesigner/FlatLaf/master/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatLaf.properties
+
+#---- variables ----
+red=#e06c75
+green=#98c379
+yellow=#e5c07b
+blue=#61afef
+magenta=#c678dd
+cyan=#56b6c2
+grey=#5c6370
+
+foreground=#dcdfe4
+background=#282c34
+backgroundDark=#21252b
+accent=$green
+
+#---- Base Variables ----
+@background=$background
+@foreground=$foreground
+separatorColor=$background
+
+#---- News ----
+News.headerColor=$green
+News.linkColor=$blue
+
+#---- Console ----
+Console.LogType.debug=$magenta
+Console.LogType.info=$green
+Console.LogType.warn=$yellow
+Console.LogType.error=$red
+Console.LogType.default=$foreground
+
+#---- Tabs ----
+tabActive=$backgroundDark
+TabbedPane.underlineColor=$accent
+TabbedPane.showTabSeparators=false
+
+#---- Button ----
+Button.foreground=$foreground
+buttonBackground=$backgroundDark
+Button.startBorderColor=$backgroundDark
+Button.endBorderColor=$backgroundDark
+Button.focusedBorderColor=$backgroundDark
+Button.hoverBorderColor=$accent
+Button.hoverBackground=$backgroundDark
+
+#---- Checkbox ----
+CheckBox.icon.background=$backgroundDark
+CheckBox.icon.borderColor=$accent
+CheckBox.icon.checkmarkColor=$accent
+CheckBox.icon.focusColor=$accent
+CheckBox.icon.focusedBorderColor=$accent
+CheckBox.icon.selectedBackground=$backgroundDark
+CheckBox.icon.selectedBorderColor=$accent
+CheckBox.icon.selectedFocusedBorderColor=$accent
+CheckBox.icon.disabledBackground=$backgroundDark
+
+#---- Text Field ----
+TextField.foreground=$foreground
+TextField.background=$backgroundDark
+TextField.caretForeground=$foreground
+TextField.inactiveForeground=$foreground
+TextField.selectionForeground=$foreground
+TextField.selectionBackground=$blue
+
+TextField.startBorderColor=$backgroundDark
+TextField.endBorderColor=$backgroundDark
+
+#---- Formated Text Field
+FormattedTextField.foreground=$foreground
+FormattedTextField.background=$backgroundDark
+FormattedTextField.caretForeground=$foreground
+FormattedTextField.selectionForeground=$foreground
+FormattedTextField.selectionBackground=$blue
+
+#---- Password Field ----
+PasswordField.foreground=$foreground
+PasswordField.background=$backgroundDark
+PasswordField.capsLockIconColor=$red
+PasswordField.caretForeground=$foreground
+PasswordField.inactiveForeground=$foreground
+PasswordField.selectionForeground=$foreground
+PasswordField.selectionBackground=$blue
+
+#---- Text Area ----
+TextArea.foreground=$foreground
+TextArea.background=$backgroundDark
+TextArea.caretForeground=$foreground
+TextArea.inactiveForeground=$foreground
+TextArea.selectionForeground=$foreground
+TextArea.selectionBackground=$blue
+
+#---- Combo Box ----
+ComboBox.foreground=$foreground
+ComboBox.background=$backgroundDark
+ComboBox.buttonBackground=$backgroundDark
+ComboBox.selectionBackground=$background
+ComboBox.selectionForeground=$accent
+ComboPopup.border=$backgroundDark
+
+#---- Spinner ----
+Spinner.foreground=$foreground
+Spinner.background=$backgroundDark
+Spinner.selectionForeground=$foreground
+Spinner.buttonBackground=$backgroundDark
+
+#---- ProgressBar ----
+ProgressBar.foreground=$accent
+ProgressBar.background=$background
+
+#---- Toaster ----
+Toaster.bgColor=$background
+Toaster.msgColor=$foreground
+Toaster.borderColor=$background
+
+#---- CollapsiblePanel ----
+CollapsiblePanel.normal=$foreground
+CollapsiblePanel.warning=$yellow
+CollapsiblePanel.error=$red
+
+#---- Component
+Component.borderColor=$backgroundDark
+Component.focusedBorderColor=$accent
+Component.disabledBorderColor=$grey
+# Component.hoverBorderColor=$accent
+Component.iconColor=$foreground
+Component.hoverIconColor=$foreground
+Component.infoForeground=$accent
+
+#---- EditorPane ----
+EditorPane.disabledBackground=$background
+EditorPane.inactiveBackground=$background
+
+#---- Mods ----
+Mods.modSelectionColor=$backgroundDark


### PR DESCRIPTION
### Description of the Change
I added a new theme based on the [Atom One Dark Theme](https://github.com/atom/one-dark-ui). I tried to make it modular, so you can define a different accent color from the color pallet, or create a completely new color pallet.

### Testing
I tested every UI widget that I found in all the main tabs, the settings and the menus for instances.

### Related Issues
*[no related issues]*

Hope you like it :)
