### PR TITLE
Defer starting analytics session on first run

### DIFF
--- a/src/main/java/com/atlauncher/Launcher.java
+++ b/src/main/java/com/atlauncher/Launcher.java
@@ -198,7 +198,7 @@ public class Launcher {
 
         checkForExternalPackUpdates();
 
-        if (App.settings.enableLogs && App.settings.enableAnalytics) {
+        if (!App.settings.firstTimeRun && App.settings.enableLogs && App.settings.enableAnalytics) {
             Analytics.startSession();
         }
         PerformanceManager.end();

--- a/src/main/java/com/atlauncher/gui/dialogs/SetupDialog.java
+++ b/src/main/java/com/atlauncher/gui/dialogs/SetupDialog.java
@@ -131,6 +131,7 @@ public class SetupDialog extends JDialog implements RelocalizationListener {
             App.settings.save();
 
             if (enableAnalytics.isSelected()) {
+                Analytics.startSession();
                 Analytics.sendEvent("SetupDialogComplete", "Launcher");
             }
 


### PR DESCRIPTION
### Description of the Change

<!-- Give us a description about this Pull Request. The more information you include the better -->
﻿This defers starting the analytics session on the first run, until such
time the user has made their choice on whether to enable.

### Testing

<!-- Have the changes in this Pull Request been test? If so how thoroughly? -->

I've set debug points to verify that certain code paths are no longer
being hit. I also no longer get an exception on the first run (the
result of blocking the GA host).

### Related Issues

<!-- Enter any related GitHub issues here -->
