### PR TITLE
Fix username Label

### DIFF
--- a/src/main/java/com/atlauncher/gui/tabs/AccountsTab.java
+++ b/src/main/java/com/atlauncher/gui/tabs/AccountsTab.java
@@ -470,7 +470,7 @@ public class AccountsTab extends JPanel implements Tab, RelocalizationListener {
             rightButton.setText(GetText.tr("Delete"));
         }
 
-        usernameLabel.setText(GetText.tr("Username/Email") + ":");
+        usernameLabel.setText(GetText.tr("Email") + ":");
         passwordLabel.setText(GetText.tr("Password") + ":");
         rememberLabel.setText(GetText.tr("Remember Password") + ":");
         updateSkin.setText(GetText.tr("Reload Skin"));


### PR DESCRIPTION
### Description of the Change

Using the Minecraft username in this entry, doesn't worked.

Only using my email address for the account worked.

### Testing

No need, it's just a rename of the text of a label

### Related Issues

None
