### PR TITLE
fix: enable IME for ArchLinux User

### DIFF
--- a/packaging/aur/atlauncher-bin/atlauncher
+++ b/packaging/aur/atlauncher-bin/atlauncher
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # fix for users of special IM modules
-unset XMODIFIERS GTK_IM_MODULE QT_IM_MODULE
+#unset XMODIFIERS GTK_IM_MODULE QT_IM_MODULE
 
 mkdir -p "${HOME}/.local/share/atlauncher"
 cd "${HOME}/.local/share/atlauncher"

--- a/packaging/aur/atlauncher/atlauncher
+++ b/packaging/aur/atlauncher/atlauncher
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # fix for users of special IM modules
-unset XMODIFIERS GTK_IM_MODULE QT_IM_MODULE
+#unset XMODIFIERS GTK_IM_MODULE QT_IM_MODULE
 
 mkdir -p "${HOME}/.local/share/atlauncher"
 cd "${HOME}/.local/share/atlauncher"


### PR DESCRIPTION
### Description of the Change

Change the shell wrapper script to enable IME(such as fcitx) in ATLauncher and minecraft.
Disable IM_MODULE won't help anything.

<!-- Give us a description about this Pull Request. The more information you include the better -->

### Testing
It's run, just change script as the commit to test.
<!-- Have the changes in this Pull Request been test? If so how thoroughly? -->

### Related Issues
Nope
<!-- Enter any related GitHub issues here -->
