### PR TITLE
fix: update Modrinth pack format per latest format changes

### DIFF
--- a/src/main/java/com/atlauncher/data/Instance.java
+++ b/src/main/java/com/atlauncher/data/Instance.java
@@ -1749,10 +1749,10 @@ public class Instance extends MinecraftVersion {
 
     public boolean exportAsModrinthZip(String name, String version, String author, String saveTo,
             List<String> overrides) {
-        Path to = Paths.get(saveTo).resolve(name + ".zip");
+        Path to = Paths.get(saveTo).resolve(name + ".mrpack");
         ModrinthModpackManifest manifest = new ModrinthModpackManifest();
 
-        manifest.formatVersion = "1";
+        manifest.formatVersion = 1;
         manifest.game = "minecraft";
         manifest.versionId = version;
         manifest.name = name;
@@ -1765,7 +1765,7 @@ public class Instance extends MinecraftVersion {
                     file.path = this.ROOT.relativize(modPath).toString().replace("\\", "/");
 
                     file.hashes = new HashMap<>();
-                    file.hashes.put("sha512", Hashing.sha512(modPath).toString());
+                    file.hashes.put("sha1", Hashing.sha1(modPath).toString());
 
                     file.env = new HashMap<>();
                     file.env.put("client", "required");
@@ -1795,11 +1795,11 @@ public class Instance extends MinecraftVersion {
         Path tempDir = FileSystem.TEMP.resolve(this.launcher.name + "-export");
         FileUtils.createDirectory(tempDir);
 
-        // create manifest.json
-        try (FileWriter fileWriter = new FileWriter(tempDir.resolve("index.json").toFile())) {
+        // create modrinth.index.json
+        try (FileWriter fileWriter = new FileWriter(tempDir.resolve("modrinth.index.json").toFile())) {
             Gsons.MINECRAFT.toJson(manifest, fileWriter);
         } catch (JsonIOException | IOException e) {
-            LogManager.logStackTrace("Failed to save index.json", e);
+            LogManager.logStackTrace("Failed to save modrinth.index.json", e);
 
             FileUtils.deleteDirectory(tempDir);
 

--- a/src/main/java/com/atlauncher/data/modrinth/pack/ModrinthModpackFile.java
+++ b/src/main/java/com/atlauncher/data/modrinth/pack/ModrinthModpackFile.java
@@ -42,9 +42,7 @@ public class ModrinthModpackFile {
         mod.download = DownloadType.direct;
         mod.file = path.substring(path.lastIndexOf("/") + 1);
         mod.path = path.substring(0, path.lastIndexOf("/"));
-        mod.sha1 = hashes.containsKey("sha1") ? hashes.get("sha1") : null;
-        mod.sha512 = hashes.containsKey("sha512") ? hashes.get("sha512") : null;
-        mod.fingerprint = hashes.containsKey("murmur2") ? Long.parseLong(hashes.get("murmur2")) : null;
+        mod.sha1 = hashes.get("sha1");
         mod.name = path.replace("mods/", "").replace(".jar", "");
         mod.url = downloads.get(0);
         mod.type = getType();

--- a/src/main/java/com/atlauncher/data/modrinth/pack/ModrinthModpackManifest.java
+++ b/src/main/java/com/atlauncher/data/modrinth/pack/ModrinthModpackManifest.java
@@ -21,7 +21,7 @@ import java.util.List;
 import java.util.Map;
 
 public class ModrinthModpackManifest {
-    public String formatVersion;
+    public int formatVersion;
     public String game;
     public String versionId;
     public String name;

--- a/src/main/java/com/atlauncher/utils/ImportPackUtils.java
+++ b/src/main/java/com/atlauncher/utils/ImportPackUtils.java
@@ -216,7 +216,7 @@ public class ImportPackUtils {
                 return false;
             }
 
-            if (Integer.parseInt(manifest.formatVersion, 10) != 1) {
+            if (manifest.formatVersion != 1) {
                 LogManager.warn("Manifest is version " + manifest.formatVersion + " which may be an issue!");
             }
 

--- a/src/main/java/com/atlauncher/workers/InstanceInstaller.java
+++ b/src/main/java/com/atlauncher/workers/InstanceInstaller.java
@@ -796,7 +796,7 @@ public class InstanceInstaller extends SwingWorker<Boolean, Void> implements Net
             throw new Exception("Cannot install as the manifest doesn't contain a minecraft dependency");
         }
 
-        if (Integer.parseInt(modrinthManifest.formatVersion, 10) != 1) {
+        if (modrinthManifest.formatVersion != 1) {
             LogManager.warn("Manifest is version " + modrinthManifest.formatVersion + " which may be an issue!");
         }
 


### PR DESCRIPTION
### Description of the Change

The Modrinth pack format has had a couple finalising touches made. These are:
  - Updating the zip name to end with the `.mrpack` extension to be distinct
  - Updating the manifest to be named `modrinth.index.json` to be distinct
  - Forcing sha1 hash

This PR also fixes an error where the format version would be saved as a string instead of an integer, thus causing the resulting pack to be noncompliant (even with the older spec).

### Testing

This has not been tested, but is a relatively small change that should not need any testing.

### Related Issues

modrinth/docs@8e282c3: [Modrinth docs page](https://docs.modrinth.com/docs/modpacks/format_definition) commit documenting these changes
modrinth/docs#18: sha1 hashes must be used in Modrinth packs
[This message](https://discord.com/channels/734077874708938864/734077874708938867/924004418188361758) in the Modrinth Discord, justification for the docs issue