### PR TITLE
fix: import Modrinth mod packs in new format

### DIFF
--- a/src/main/java/com/atlauncher/gui/dialogs/ImportInstanceDialog.java
+++ b/src/main/java/com/atlauncher/gui/dialogs/ImportInstanceDialog.java
@@ -161,7 +161,7 @@ public class ImportInstanceDialog extends JDialog {
                 chooser.setFileFilter(new FileFilter() {
                     @Override
                     public String getDescription() {
-                        return "Modpack Export (.zip)";
+                        return "Modpack Export (.zip, .mrpack)";
                     }
 
                     @Override
@@ -170,7 +170,7 @@ public class ImportInstanceDialog extends JDialog {
                             return true;
                         }
 
-                        return f.getName().endsWith(".zip");
+                        return f.getName().endsWith(".zip") || f.getName().endsWith(".mrpack");
                     }
                 });
 

--- a/src/main/java/com/atlauncher/utils/ImportPackUtils.java
+++ b/src/main/java/com/atlauncher/utils/ImportPackUtils.java
@@ -129,7 +129,7 @@ public class ImportPackUtils {
                 return loadCurseForgeFormat(file, null, null);
             }
 
-            if (ArchiveUtils.archiveContainsFile(file.toPath(), "index.json")) {
+            if (ArchiveUtils.archiveContainsFile(file.toPath(), "modrinth.index.json")) {
                 return loadModrinthFormat(file);
             }
 
@@ -194,8 +194,8 @@ public class ImportPackUtils {
     }
 
     public static boolean loadModrinthFormat(File file) {
-        if (!file.getName().endsWith(".zip")) {
-            LogManager.error("Cannot install as the file was not a zip file");
+        if (!file.getName().endsWith(".mrpack")) {
+            LogManager.error("Cannot install as the file was not a mrpack file");
             return false;
         }
 
@@ -203,7 +203,7 @@ public class ImportPackUtils {
 
         try {
             ModrinthModpackManifest manifest = Gsons.MINECRAFT
-                    .fromJson(ArchiveUtils.getFile(file.toPath(), "index.json"), ModrinthModpackManifest.class);
+                    .fromJson(ArchiveUtils.getFile(file.toPath(), "modrinth.index.json"), ModrinthModpackManifest.class);
 
             if (!manifest.game.equals("minecraft")) {
                 LogManager.error(


### PR DESCRIPTION
### Description of the Change

This is a supplemental PR to #539 that fixes importing of Modrinth mod packs in the new format. Making .mrpack files selectable in the file dialogue, as well as searching for the proper modrinth.index.json file.

### Testing

Tested them locally with packwiz generated mod pack.