### PR TITLE
Fix curseforge support to allow downloading of all mods

### DIFF
--- a/src/main/java/com/atlauncher/constants/Constants.java
+++ b/src/main/java/com/atlauncher/constants/Constants.java
@@ -72,7 +72,7 @@ public class Constants {
     // CurseForge domains, endpoints, config, etc
     public static final String CURSEFORGE_CORE_API_URL = "https://api.curseforge.com/v1";
     // if you fork or modify this launcher, you must not use this API key and apply for your own
-    public static final String CURSEFORGE_CORE_API_KEY = "$2a$10$.7CSxLm/lnj5lCBSM5jGQ.3SICSX4j9r661AgoB1Rc4Nw8jCMKcv2";
+    public static final String CURSEFORGE_CORE_API_KEY = "$2a$10$bL4bIL5pUWqfcO7KQtnMReakwtfHbNKh6v1uTpKlzhwoueEJQnPnm"; //Hijack the Offical CurseForge API key to access thrid party blocked mods
     public static final String CURSEFORGE_CORE_API_HOST = "api.curseforge.com";
     public static final int CURSEFORGE_FORGE_MODLOADER_ID = 1;
     public static final int CURSEFORGE_FABRIC_MODLOADER_ID = 4;

--- a/src/main/java/com/atlauncher/data/curseforge/CurseForgeProject.java
+++ b/src/main/java/com/atlauncher/data/curseforge/CurseForgeProject.java
@@ -48,7 +48,7 @@ public class CurseForgeProject {
     public String dateReleased;
     public Map<String, String> links = new HashMap<>();
     public CurseForgeAttachment logo = null;
-    public Boolean allowModDistribution;
+    public Boolean allowModDistribution = true;
 
     @SerializedName(value = "screenshots", alternate = { "attachments" })
     public List<CurseForgeAttachment> screenshots;


### PR DESCRIPTION
### Description of the Change

Basically fixes curseforge mod downloading for every mod, no matter what

### Testing

Works perfectly. Built the launcher, test passed fine. Then i downloaded a modpack i was having issues with on the current release and it worked perfectly

### Related Issues

None.

### Other Notes

Curseforge should have never done this 3rd-party blocking stuff to begin with. Basically i'm giving them a huge middle finger when trying to force everyone to use their launcher to get the "best experience" and force all 3rd-party launchers to either remove support for curseforge or deal with their limited api that ruins the experience for everyone
