### PR TITLE
Add xdg-portal FileChooser via extension jar

### DIFF
--- a/src/main/java/com/atlauncher/App.java
+++ b/src/main/java/com/atlauncher/App.java
@@ -59,6 +59,7 @@ import com.atlauncher.data.Instance;
 import com.atlauncher.data.Language;
 import com.atlauncher.data.Pack;
 import com.atlauncher.data.Settings;
+import com.atlauncher.extension.ExtensionUtils;
 import com.atlauncher.gui.LauncherConsole;
 import com.atlauncher.gui.LauncherFrame;
 import com.atlauncher.gui.SplashScreen;
@@ -440,6 +441,9 @@ public class App {
 
         if (OS.isUsingFlatpak()) {
             LogManager.info("Using Flatpak!");
+            if (ExtensionUtils.hasFlatpakExtension()) {
+                LogManager.info("Has flatpak extension");
+            }
         }
 
         try {

--- a/src/main/java/com/atlauncher/extension/ExtensionUtils.java
+++ b/src/main/java/com/atlauncher/extension/ExtensionUtils.java
@@ -1,0 +1,100 @@
+/*
+ * ATLauncher - https://github.com/ATLauncher/ATLauncher
+ * Copyright (C) 2013-2022 ATLauncher
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.atlauncher.extension;
+
+import com.atlauncher.managers.LogManager;
+import com.atlauncher.utils.OS;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+
+/**
+ * 04 / 06 / 2022
+ */
+public class ExtensionUtils {
+    public static boolean hasFlatpakExtension() {
+        return OS.isUsingFlatpak() && new File("/app/bin/atlauncherx-flatpak.jar").exists();
+    }
+
+    /**
+     * Uses another jar to handle loading files in flatpak
+     */
+    public static File[] selectFilesFromExtension() {
+        LogManager.debug("Using separate jar");
+
+        String command = "java -jar /app/bin/atlauncherx-flatpak.jar";
+        Process child = null;
+        try {
+            LogManager.debug("Executing process");
+            child = Runtime.getRuntime().exec(command);
+
+            {
+                BufferedReader br = new BufferedReader(
+                    new InputStreamReader(child.getErrorStream())
+                );
+
+                String s;
+                while ((s = br.readLine()) != null) {
+                    LogManager.error(s);
+                }
+            }
+
+            BufferedReader br = new BufferedReader(
+                new InputStreamReader(child.getInputStream())
+            );
+            StringBuilder builder = new StringBuilder();
+            String s;
+            while ((s = br.readLine()) != null) {
+                builder.append(s);
+            }
+
+            LogManager.debug("Waiting for process to finish");
+            int resultCode = child.waitFor();
+            LogManager.debug("Final code: " + resultCode);
+
+            // We can be guaranteed that this will always be either empty, "[]", or "[...]", or "[...,...]"
+            String result = builder.toString();
+            LogManager.debug("Result string: '" + result + "'");
+
+            String[] selectedFiles;
+
+            if (result.length() >= 2) {
+                LogManager.debug("Spitting path");
+                selectedFiles = result.substring(1, result.length() - 1)
+                    .split(",");
+            } else {
+                LogManager.debug("Too small, returning default");
+                return new File[0];
+            }
+
+            return Arrays.stream(selectedFiles)
+                .map(File::new).toArray(size -> new File[selectedFiles.length]);
+        } catch (IOException | InterruptedException e) {
+            LogManager.debug("Exception occurred");
+            LogManager.logStackTrace(e);
+        } finally {
+            LogManager.debug("Destroying process");
+            if (child != null)
+                child.destroy();
+        }
+        return new File[0];
+    }
+}

--- a/src/main/java/com/atlauncher/gui/dialogs/FileChooserDialog.java
+++ b/src/main/java/com/atlauncher/gui/dialogs/FileChooserDialog.java
@@ -45,6 +45,7 @@ import javax.swing.filechooser.FileFilter;
 import com.atlauncher.App;
 import com.atlauncher.FileSystem;
 import com.atlauncher.constants.UIConstants;
+import com.atlauncher.extension.ExtensionUtils;
 import com.atlauncher.utils.Utils;
 
 import org.mini2Dx.gettext.GetText;
@@ -61,7 +62,7 @@ public class FileChooserDialog extends JDialog {
     private boolean closed = false;
 
     public FileChooserDialog(Window parent, String title, String labelName, String bottomText, String selectorText,
-            String[] subOptions) {
+                             String[] subOptions) {
         super(parent, title, ModalityType.DOCUMENT_MODAL);
         setSize(400, 175);
         setMinimumSize(new Dimension(400, 175));
@@ -99,7 +100,9 @@ public class FileChooserDialog extends JDialog {
 
         JButton selectButton = new JButton(GetText.tr("Select"));
         selectButton.addActionListener(e -> {
-            if (App.settings.useNativeFilePicker) {
+            if (ExtensionUtils.hasFlatpakExtension()) {
+                filesChosen = ExtensionUtils.selectFilesFromExtension();
+            } else if (App.settings.useNativeFilePicker) {
                 filesChosen = getFilesUsingFileDialog();
             } else {
                 filesChosen = getFilesUsingJFileChooser();

--- a/src/main/java/com/atlauncher/gui/dialogs/ImportInstanceDialog.java
+++ b/src/main/java/com/atlauncher/gui/dialogs/ImportInstanceDialog.java
@@ -45,9 +45,11 @@ import com.atlauncher.App;
 import com.atlauncher.FileSystem;
 import com.atlauncher.builders.HTMLBuilder;
 import com.atlauncher.constants.UIConstants;
+import com.atlauncher.extension.ExtensionUtils;
 import com.atlauncher.managers.DialogManager;
 import com.atlauncher.network.Analytics;
 import com.atlauncher.utils.ImportPackUtils;
+import com.atlauncher.utils.OS;
 import com.atlauncher.utils.Utils;
 
 import org.mini2Dx.gettext.GetText;
@@ -134,7 +136,14 @@ public class ImportInstanceDialog extends JDialog {
 
         JButton browseButton = new JButton(GetText.tr("Browse"));
         browseButton.addActionListener(e -> {
-            if (App.settings.useNativeFilePicker) {
+            if (OS.isUsingFlatpak() && ExtensionUtils.hasFlatpakExtension()) {
+                File[] filesChosen = ExtensionUtils.selectFilesFromExtension();
+
+                if (filesChosen.length != 0) {
+                    filePath.setText(filesChosen[0].getAbsolutePath());
+                    changeAddButtonStatus();
+                }
+            } else if (App.settings.useNativeFilePicker) {
                 FileDialog fileDialog = new FileDialog(this, GetText.tr("Select file/s"), FileDialog.LOAD);
                 fileDialog.setFilenameFilter(new FilenameFilter() {
                     @Override


### PR DESCRIPTION
### Description of the Change

If having a dbus API messes with Minecraft Forge 1.16.#,
 We can simply have another application handle the calls,
 simplifying what we need to do.
 
Utilizing the newly created program hosted [here](https://gitlab.com/Doomsdayrs/atlauncherx-flatpak)

### Testing

- I have tested adding a jar, it seems to add the jar but the console throws out strange errors regarding zip? 
Could you take a look at them?
- I have tested Minecraft 1.16 and 1.16.5

### Related Issues

#564 
