### PR TITLE
Remove JCenter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,6 @@ version = rootProject.file('src/main/resources/version').text.trim().replace('.B
 repositories {
     mavenCentral()
     gradlePluginPortal()
-    jcenter()
     maven {
         url 'https://libraries.minecraft.net'
     }


### PR DESCRIPTION
### Description of the Change

JCenter is a deprecated repository, Thankfully nothing uses it in the project.

### Testing

Build runs fine, I do not expect this to cause any runtime changes. If you feel it might, I can test that too.
