### PR TITLE
Fix archiveutils

### DIFF
--- a/src/main/java/com/atlauncher/gui/dialogs/ImportInstanceDialog.java
+++ b/src/main/java/com/atlauncher/gui/dialogs/ImportInstanceDialog.java
@@ -140,7 +140,7 @@ public class ImportInstanceDialog extends JDialog {
                 File[] filesChosen = DBusUtils.selectFiles();
 
                 if (filesChosen.length != 0) {
-                    filePath.setText(filesChosen[0].getAbsolutePath());
+                    filePath.setText(filesChosen[0].getPath());
                     changeAddButtonStatus();
                 }
             } else if (App.settings.useNativeFilePicker) {

--- a/src/main/java/com/atlauncher/utils/ArchiveUtils.java
+++ b/src/main/java/com/atlauncher/utils/ArchiveUtils.java
@@ -55,8 +55,8 @@ public class ArchiveUtils {
 
         boolean found = false;
 
-        try (InputStream is = Files.newInputStream(archivePath);
-                ZipArchiveInputStream zais = new ZipArchiveInputStream(is, "UTF8", true, true)) {
+        try (InputStream is = createInputStream(archivePath);
+             ZipArchiveInputStream zais = new ZipArchiveInputStream(is, "UTF8", true, true)) {
             ArchiveEntry entry = null;
             while ((entry = zais.getNextEntry()) != null) {
                 if (!zais.canReadEntryData(entry)) {
@@ -82,7 +82,7 @@ public class ArchiveUtils {
      * @param archivePath Path to create an input stream for.
      * @return Input stream if successful, null otherwise
      */
-    public static @Nullable InputStream createStream(Path archivePath) {
+    public static @Nullable InputStream createInputStream(Path archivePath) {
         InputStream is = null;
 
         try {
@@ -100,7 +100,7 @@ public class ArchiveUtils {
 
     public static String getFile(Path archivePath, String file) {
         try {
-            return new String(ZipUtil.unpackEntry(createStream(archivePath), file));
+            return new String(ZipUtil.unpackEntry(createInputStream(archivePath), file));
         } catch (Throwable t) {
             // allow this to fail as we can fallback to Apache Commons library
             LOG.debug("Failed to get contents of file in " + archivePath.toAbsolutePath() + ". Trying fallback method");
@@ -109,7 +109,7 @@ public class ArchiveUtils {
         String contents = null;
 
         try {
-            InputStream is = createStream(archivePath);
+            InputStream is = createInputStream(archivePath);
             try (
                     ArchiveInputStream ais = new ArchiveStreamFactory().createArchiveInputStream("ZIP", is)) {
                 ArchiveEntry entry = null;
@@ -146,8 +146,8 @@ public class ArchiveUtils {
             LOG.error("Failed to extract {}", archivePath.toAbsolutePath());
         }
 
-        try (InputStream is = Files.newInputStream(archivePath);
-                ZipArchiveInputStream zais = new ZipArchiveInputStream(is, "UTF8", true, true)) {
+        try (InputStream is = createInputStream(archivePath);
+             ZipArchiveInputStream zais = new ZipArchiveInputStream(is, "UTF8", true, true)) {
             ArchiveEntry entry = null;
             while ((entry = zais.getNextEntry()) != null) {
                 if (!zais.canReadEntryData(entry)) {
@@ -208,6 +208,9 @@ public class ArchiveUtils {
                     pathToCompress.toAbsolutePath());
         }
 
+        // TODO, It seems that exports currently do not use dbus for dir sel,
+        //  it would be optimal to be aware the below line will cause problems
+        //  once dbus is setup for export as well
         try (OutputStream os = Files.newOutputStream(archivePath);
                 ArchiveOutputStream aos = new ArchiveStreamFactory().createArchiveOutputStream("ZIP", os)) {
 

--- a/src/main/java/com/atlauncher/utils/Utils.java
+++ b/src/main/java/com/atlauncher/utils/Utils.java
@@ -318,7 +318,7 @@ public class Utils {
                 destination = new FileOutputStream(to).getChannel();
                 destination.transferFrom(source, 0, source.size());
             } else {
-                sourceStream = ArchiveUtils.createStream(from.toPath());
+                sourceStream = ArchiveUtils.createInputStream(from.toPath());
                 destinationStream = new FileOutputStream(to);
                 IOUtils.copy(sourceStream, destinationStream);
             }


### PR DESCRIPTION
### Description of the Change

- Rename ArchiveUtils.createStream to createInputStream
- ArchiveUtils was improperly using createInputStream, this was fixed.
- ImportInstanceDialog was using getAbsolutePath for dbus URIs

### Testing

Select mod zip file via dbus. Import. All worked.

### Related Issues

Discord: Channel 985300094817538088

