### PR TITLE
Prioritize MultiMC over CurseForge/Modrinth when importing

### DIFF
--- a/src/main/java/com/atlauncher/utils/ImportPackUtils.java
+++ b/src/main/java/com/atlauncher/utils/ImportPackUtils.java
@@ -171,14 +171,6 @@ public class ImportPackUtils {
 
     public static boolean loadFromFile(File file) {
         try {
-            if (ArchiveUtils.archiveContainsFile(file.toPath(), "manifest.json")) {
-                return loadCurseForgeFormat(file, null, null);
-            }
-
-            if (ArchiveUtils.archiveContainsFile(file.toPath(), "modrinth.index.json")) {
-                return loadModrinthFormat(file);
-            }
-
             Path tmpDir = FileSystem.TEMP.resolve("multimcimport" + file.getName().toString().toLowerCase());
 
             ArchiveUtils.extract(file.toPath(), tmpDir);
@@ -193,6 +185,14 @@ public class ImportPackUtils {
             }
 
             FileUtils.deleteDirectory(tmpDir);
+            
+            if (ArchiveUtils.archiveContainsFile(file.toPath(), "manifest.json")) {
+                return loadCurseForgeFormat(file, null, null);
+            }
+
+            if (ArchiveUtils.archiveContainsFile(file.toPath(), "modrinth.index.json")) {
+                return loadModrinthFormat(file);
+            }
 
             LogManager.error("Unknown format for importing");
         } catch (Throwable t) {


### PR DESCRIPTION
### Description of the Change

This pull request changes the order of checks during an instance import to check for MultiMC before CurseForge or Modrinth. ATLauncher supports a few features that MultiMC also has (such as wrapper commands), but because ATLauncher checks for CurseForge and Modrinth first, a ZIP file that supports being imported in both CurseForge and MultiMC doesn't get MultiMC settings. This pull request changes the order, which fixes that.

### Testing

I have tested this with a ZIP file that can be successfully imported into both CurseForge and MultiMC. The MultiMC-specific settings are imported following this change.

### Related Issues

As far as I know, there are no related issues.
