### PR TITLE
Implement semantic versioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This changelog only contains the changes that are unreleased. For changes for in
 ## 3.4.28.2O
 
 ### New Features
+- Add support for semantic versioning
 
 ### Fixes
 - Make Console sizing a bit more responsive and flexible with sizes

--- a/src/main/java/com/atlauncher/constants/Constants.java
+++ b/src/main/java/com/atlauncher/constants/Constants.java
@@ -33,16 +33,42 @@ public class Constants {
                 .collect(Collectors.joining("")).trim();
         String[] versionParts = versionFromFile.split("\\.", 4);
 
+        String reservedS, majorS, minorS, patchS;
         String stream = "Release";
 
-        if (versionParts[3].endsWith(".Beta")) {
-            versionParts[3] = versionParts[3].replace(".Beta", "");
-            stream = "Beta";
+        if (versionParts.length == 3) {
+            reservedS = null;
+            majorS = versionParts[0];
+            minorS = versionParts[1];
+            patchS = versionParts[2];
+        } else {
+            reservedS = versionParts[0];
+            majorS = versionParts[1];
+            minorS = versionParts[2];
+            patchS = versionParts[3];
         }
 
-        VERSION = new LauncherVersion(Integer.parseInt(versionParts[0]), Integer.parseInt(versionParts[1]),
-                Integer.parseInt(versionParts[2]), Integer.parseInt(versionParts[3]), stream,
-                OS.getRunningProgramHashCode());
+
+        if (patchS.endsWith(".Beta")) {
+            patchS = patchS.replace(".Beta", "");
+            stream = "Beta";
+        }
+        Integer reserved;
+
+        if (reservedS == null) {
+            reserved = null;
+        } else {
+            reserved = Integer.parseInt(reservedS);
+        }
+
+        VERSION = new LauncherVersion(
+            reserved,
+            Integer.parseInt(majorS),
+            Integer.parseInt(minorS),
+            Integer.parseInt(patchS),
+            stream,
+            OS.getRunningProgramHashCode()
+        );
     }
 
     // Launcher config

--- a/src/main/java/com/atlauncher/constants/Constants.java
+++ b/src/main/java/com/atlauncher/constants/Constants.java
@@ -53,10 +53,10 @@ public class Constants {
             patchS = patchS.replace(".Beta", "");
             stream = "Beta";
         }
-        Integer reserved;
+        int reserved;
 
         if (reservedS == null) {
-            reserved = null;
+            reserved = 99;
         } else {
             reserved = Integer.parseInt(reservedS);
         }

--- a/src/main/java/com/atlauncher/data/LauncherVersion.java
+++ b/src/main/java/com/atlauncher/data/LauncherVersion.java
@@ -22,22 +22,21 @@ import java.util.Locale;
 import com.atlauncher.annot.Json;
 import com.atlauncher.utils.Hashing;
 import com.google.common.hash.HashCode;
-import org.jetbrains.annotations.Nullable;
 
 @Json
 public class LauncherVersion {
-    private final @Nullable Integer reserved;
+    private final int reserved;
     private final int major;
     private final int minor;
     private final int revision;
     private final String stream;
     private final HashCode sha1Revision;
 
-    public LauncherVersion(@Nullable Integer reserved, int major, int minor, int revision) {
+    public LauncherVersion(int reserved, int major, int minor, int revision) {
         this(reserved, major, minor, revision, "Release", Hashing.EMPTY_HASH_CODE);
     }
 
-    public LauncherVersion(@Nullable Integer reserved, int major, int minor, int revision, String stream, HashCode sha1Revision) {
+    public LauncherVersion(int reserved, int major, int minor, int revision, String stream, HashCode sha1Revision) {
         this.reserved = reserved;
         this.major = major;
         this.minor = minor;
@@ -46,7 +45,7 @@ public class LauncherVersion {
         this.sha1Revision = sha1Revision;
     }
 
-    public @Nullable Integer getReserved() {
+    public int getReserved() {
         return this.reserved;
     }
 
@@ -75,38 +74,30 @@ public class LauncherVersion {
     }
 
     public boolean needsUpdate(LauncherVersion toThis) {
-        if (reserved != null && toThis.getReserved() != null) {
-            if (this.reserved > toThis.getReserved()) {
-                return false;
-            } else if (this.reserved < toThis.getReserved()) {
-                return true;
-            }
-        } else {
-            // Because the other one has it null, and this one is not.
-            // This is clearly older (not using semver).
-            if (reserved != null && toThis.getReserved() == null) {
-                return true;
-            }
-        }
-
-        if (this.major > toThis.getMajor()) {
+        if (this.reserved > toThis.getReserved()) {
             return false;
-        } else if (this.major < toThis.getMajor()) {
+        } else if (this.reserved < toThis.getReserved()) {
             return true;
         } else {
-            if (this.minor > toThis.getMinor()) {
+            if (this.major > toThis.getMajor()) {
                 return false;
-            } else if (this.minor < toThis.getMinor()) {
+            } else if (this.major < toThis.getMajor()) {
                 return true;
             } else {
-                if (this.revision > toThis.getRevision()) {
+                if (this.minor > toThis.getMinor()) {
                     return false;
-                } else if (this.revision < toThis.getRevision()) {
+                } else if (this.minor < toThis.getMinor()) {
                     return true;
                 } else {
-                    // if versions are the same, update if current version is not a release stream
-                    // but new version is in release stream
-                    return !this.isReleaseStream() && toThis.isReleaseStream();
+                    if (this.revision > toThis.getRevision()) {
+                        return false;
+                    } else if (this.revision < toThis.getRevision()) {
+                        return true;
+                    } else {
+                        // if versions are the same, update if current version is not a release stream
+                        // but new version is in release stream
+                        return !this.isReleaseStream() && toThis.isReleaseStream();
+                    }
                 }
             }
         }

--- a/src/test/java/com/atlauncher/data/LauncherVersionTest.java
+++ b/src/test/java/com/atlauncher/data/LauncherVersionTest.java
@@ -17,112 +17,78 @@
  */
 package com.atlauncher.data;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.junit.jupiter.api.Test;
 
 import com.atlauncher.utils.Hashing;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 public class LauncherVersionTest {
 
     private static final LauncherVersion testVersion = new LauncherVersion(1, 0, 0, 0, "Release",
         Hashing.EMPTY_HASH_CODE);
 
-    private static final LauncherVersion semanticVersion = new LauncherVersion(null, 0, 0, 0, "Release",
+    private static final LauncherVersion semanticTestVersion = new LauncherVersion(99, 0, 0, 0, "Release",
         Hashing.EMPTY_HASH_CODE);
 
     @Test
     public void test() {
-        LauncherVersion[] versions = {testVersion, semanticVersion};
-        for (LauncherVersion version : versions) {
-
+        LauncherVersion[] versions = {testVersion, semanticTestVersion};
+        for (LauncherVersion testVersion : versions) {
             // Test same version - no update
-            assertFalse(version.needsUpdate(new LauncherVersion(version.getReserved(), version.getMajor(),
-                version.getMinor(), version.getRevision(), version.getStream(),
+            assertFalse(testVersion.needsUpdate(new LauncherVersion(testVersion.getReserved(), testVersion.getMajor(),
+                testVersion.getMinor(), testVersion.getRevision(), testVersion.getStream(),
                 Hashing.EMPTY_HASH_CODE)));
 
             // Test older Reserved - launcher had a big update
-            if (version.getReserved() != null) {
-                assertTrue(
-                    version.needsUpdate(
-                        new LauncherVersion(
-                            version.getReserved() + 1,
-                            version.getMajor(),
-                            version.getMinor(),
-                            version.getRevision(),
-                            version.getStream(),
-                            Hashing.EMPTY_HASH_CODE
-                        )
-                    )
-                );
-            }
-
-            // Test old to new semver
-            if (version.getReserved() != null)
-                assertTrue(
-                    version.needsUpdate(
-                        new LauncherVersion(
-                            null,
-                            version.getMajor(),
-                            version.getMinor(),
-                            version.getRevision(),
-                            version.getStream(),
-                            Hashing.EMPTY_HASH_CODE
-                        )
-                    )
-                );
+            assertTrue(testVersion.needsUpdate(new LauncherVersion(testVersion.getReserved() + 1, testVersion.getMajor(),
+                testVersion.getMinor(), testVersion.getRevision(), testVersion.getStream(),
+                Hashing.EMPTY_HASH_CODE)));
 
             // Test older Major - launcher had major update
-            assertTrue(version.needsUpdate(new LauncherVersion(version.getReserved(), version.getMajor() + 1,
-                version.getMinor(), version.getRevision(), version.getStream(),
+            assertTrue(testVersion.needsUpdate(new LauncherVersion(testVersion.getReserved(), testVersion.getMajor() + 1,
+                testVersion.getMinor(), testVersion.getRevision(), testVersion.getStream(),
                 Hashing.EMPTY_HASH_CODE)));
 
             // Test older Minor - launcher had minor update
-            assertTrue(version.needsUpdate(new LauncherVersion(version.getReserved(), version.getMajor(),
-                version.getMinor() + 1, version.getRevision(), version.getStream(),
+            assertTrue(testVersion.needsUpdate(new LauncherVersion(testVersion.getReserved(), testVersion.getMajor(),
+                testVersion.getMinor() + 1, testVersion.getRevision(), testVersion.getStream(),
                 Hashing.EMPTY_HASH_CODE)));
 
             // Test older Revision - launcher had a bug fix
-            assertTrue(version.needsUpdate(new LauncherVersion(version.getReserved(), version.getMajor(),
-                version.getMinor(), version.getRevision() + 1, version.getStream(),
+            assertTrue(testVersion.needsUpdate(new LauncherVersion(testVersion.getReserved(), testVersion.getMajor(),
+                testVersion.getMinor(), testVersion.getRevision() + 1, testVersion.getStream(),
                 Hashing.EMPTY_HASH_CODE)));
 
             // Test user has a beta stream but the real stream comes out
-            LauncherVersion betaBuild = new LauncherVersion(version.getReserved(), version.getMajor(),
-                version.getMinor(), version.getRevision(), "Beta", Hashing.EMPTY_HASH_CODE);
-            LauncherVersion releaseBuild = new LauncherVersion(version.getReserved(), version.getMajor(),
-                version.getMinor(), version.getRevision(), "Release", Hashing.EMPTY_HASH_CODE);
+            LauncherVersion betaBuild = new LauncherVersion(testVersion.getReserved(), testVersion.getMajor(),
+                testVersion.getMinor(), testVersion.getRevision(), "Beta", Hashing.EMPTY_HASH_CODE);
+            LauncherVersion releaseBuild = new LauncherVersion(testVersion.getReserved(), testVersion.getMajor(),
+                testVersion.getMinor(), testVersion.getRevision(), "Release", Hashing.EMPTY_HASH_CODE);
             assertTrue(betaBuild.needsUpdate(releaseBuild));
 
             // Test user has a release stream but a beta build comes out
             assertFalse(releaseBuild.needsUpdate(betaBuild));
 
-            if (version.getReserved() != null) {
-                // Test newer Reserved - launcher dev version
-                assertFalse(version.needsUpdate(new LauncherVersion(version.getReserved() - 1, version.getMajor(),
-                    version.getMinor(), version.getRevision(), version.getStream(),
-                    Hashing.EMPTY_HASH_CODE)));
-            } else {
-                // Test newer semver to current old versioning
-                assertFalse(version.needsUpdate(new LauncherVersion(1, version.getMajor(),
-                    version.getMinor(), version.getRevision(), version.getStream(),
-                    Hashing.EMPTY_HASH_CODE)));
-            }
-
+            // Test newer Reserved - launcher dev version
+            assertFalse(testVersion.needsUpdate(new LauncherVersion(testVersion.getReserved() - 1, testVersion.getMajor(),
+                testVersion.getMinor(), testVersion.getRevision(), testVersion.getStream(),
+                Hashing.EMPTY_HASH_CODE)));
 
             // Test newer Major - launcher dev version
-            assertFalse(version.needsUpdate(new LauncherVersion(version.getReserved(), version.getMajor() - 1,
-                version.getMinor(), version.getRevision(), version.getStream(),
+            assertFalse(testVersion.needsUpdate(new LauncherVersion(testVersion.getReserved(), testVersion.getMajor() - 1,
+                testVersion.getMinor(), testVersion.getRevision(), testVersion.getStream(),
                 Hashing.EMPTY_HASH_CODE)));
 
             // Test newer Minor - launcher dev version
-            assertFalse(version.needsUpdate(new LauncherVersion(version.getReserved(), version.getMajor(),
-                version.getMinor() - 1, version.getRevision(), version.getStream(),
+            assertFalse(testVersion.needsUpdate(new LauncherVersion(testVersion.getReserved(), testVersion.getMajor(),
+                testVersion.getMinor() - 1, testVersion.getRevision(), testVersion.getStream(),
                 Hashing.EMPTY_HASH_CODE)));
 
             // Test newer Revision - launcher dev version
-            assertFalse(version.needsUpdate(new LauncherVersion(version.getReserved(), version.getMajor(),
-                version.getMinor(), version.getRevision() - 1, version.getStream(),
+            assertFalse(testVersion.needsUpdate(new LauncherVersion(testVersion.getReserved(), testVersion.getMajor(),
+                testVersion.getMinor(), testVersion.getRevision() - 1, testVersion.getStream(),
                 Hashing.EMPTY_HASH_CODE)));
         }
     }

--- a/src/test/java/com/atlauncher/data/LauncherVersionTest.java
+++ b/src/test/java/com/atlauncher/data/LauncherVersionTest.java
@@ -17,74 +17,114 @@
  */
 package com.atlauncher.data;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import org.junit.jupiter.api.Test;
 
 import com.atlauncher.utils.Hashing;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 public class LauncherVersionTest {
 
     private static final LauncherVersion testVersion = new LauncherVersion(1, 0, 0, 0, "Release",
-            Hashing.EMPTY_HASH_CODE);
+        Hashing.EMPTY_HASH_CODE);
+
+    private static final LauncherVersion semanticVersion = new LauncherVersion(null, 0, 0, 0, "Release",
+        Hashing.EMPTY_HASH_CODE);
 
     @Test
     public void test() {
-        // Test same version - no update
-        assertFalse(testVersion.needsUpdate(new LauncherVersion(testVersion.getReserved(), testVersion.getMajor(),
-                testVersion.getMinor(), testVersion.getRevision(), testVersion.getStream(),
+        LauncherVersion[] versions = {testVersion, semanticVersion};
+        for (LauncherVersion version : versions) {
+
+            // Test same version - no update
+            assertFalse(version.needsUpdate(new LauncherVersion(version.getReserved(), version.getMajor(),
+                version.getMinor(), version.getRevision(), version.getStream(),
                 Hashing.EMPTY_HASH_CODE)));
 
-        // Test older Reserved - launcher had a big update
-        assertTrue(testVersion.needsUpdate(new LauncherVersion(testVersion.getReserved() + 1, testVersion.getMajor(),
-                testVersion.getMinor(), testVersion.getRevision(), testVersion.getStream(),
+            // Test older Reserved - launcher had a big update
+            if (version.getReserved() != null) {
+                assertTrue(
+                    version.needsUpdate(
+                        new LauncherVersion(
+                            version.getReserved() + 1,
+                            version.getMajor(),
+                            version.getMinor(),
+                            version.getRevision(),
+                            version.getStream(),
+                            Hashing.EMPTY_HASH_CODE
+                        )
+                    )
+                );
+            }
+
+            // Test old to new semver
+            if (version.getReserved() != null)
+                assertTrue(
+                    version.needsUpdate(
+                        new LauncherVersion(
+                            null,
+                            version.getMajor(),
+                            version.getMinor(),
+                            version.getRevision(),
+                            version.getStream(),
+                            Hashing.EMPTY_HASH_CODE
+                        )
+                    )
+                );
+
+            // Test older Major - launcher had major update
+            assertTrue(version.needsUpdate(new LauncherVersion(version.getReserved(), version.getMajor() + 1,
+                version.getMinor(), version.getRevision(), version.getStream(),
                 Hashing.EMPTY_HASH_CODE)));
 
-        // Test older Major - launcher had major update
-        assertTrue(testVersion.needsUpdate(new LauncherVersion(testVersion.getReserved(), testVersion.getMajor() + 1,
-                testVersion.getMinor(), testVersion.getRevision(), testVersion.getStream(),
+            // Test older Minor - launcher had minor update
+            assertTrue(version.needsUpdate(new LauncherVersion(version.getReserved(), version.getMajor(),
+                version.getMinor() + 1, version.getRevision(), version.getStream(),
                 Hashing.EMPTY_HASH_CODE)));
 
-        // Test older Minor - launcher had minor update
-        assertTrue(testVersion.needsUpdate(new LauncherVersion(testVersion.getReserved(), testVersion.getMajor(),
-                testVersion.getMinor() + 1, testVersion.getRevision(), testVersion.getStream(),
+            // Test older Revision - launcher had a bug fix
+            assertTrue(version.needsUpdate(new LauncherVersion(version.getReserved(), version.getMajor(),
+                version.getMinor(), version.getRevision() + 1, version.getStream(),
                 Hashing.EMPTY_HASH_CODE)));
 
-        // Test older Revision - launcher had a bug fix
-        assertTrue(testVersion.needsUpdate(new LauncherVersion(testVersion.getReserved(), testVersion.getMajor(),
-                testVersion.getMinor(), testVersion.getRevision() + 1, testVersion.getStream(),
+            // Test user has a beta stream but the real stream comes out
+            LauncherVersion betaBuild = new LauncherVersion(version.getReserved(), version.getMajor(),
+                version.getMinor(), version.getRevision(), "Beta", Hashing.EMPTY_HASH_CODE);
+            LauncherVersion releaseBuild = new LauncherVersion(version.getReserved(), version.getMajor(),
+                version.getMinor(), version.getRevision(), "Release", Hashing.EMPTY_HASH_CODE);
+            assertTrue(betaBuild.needsUpdate(releaseBuild));
+
+            // Test user has a release stream but a beta build comes out
+            assertFalse(releaseBuild.needsUpdate(betaBuild));
+
+            if (version.getReserved() != null) {
+                // Test newer Reserved - launcher dev version
+                assertFalse(version.needsUpdate(new LauncherVersion(version.getReserved() - 1, version.getMajor(),
+                    version.getMinor(), version.getRevision(), version.getStream(),
+                    Hashing.EMPTY_HASH_CODE)));
+            } else {
+                // Test newer semver to current old versioning
+                assertFalse(version.needsUpdate(new LauncherVersion(1, version.getMajor(),
+                    version.getMinor(), version.getRevision(), version.getStream(),
+                    Hashing.EMPTY_HASH_CODE)));
+            }
+
+
+            // Test newer Major - launcher dev version
+            assertFalse(version.needsUpdate(new LauncherVersion(version.getReserved(), version.getMajor() - 1,
+                version.getMinor(), version.getRevision(), version.getStream(),
                 Hashing.EMPTY_HASH_CODE)));
 
-        // Test user has a beta stream but the real stream comes out
-        LauncherVersion betaBuild = new LauncherVersion(testVersion.getReserved(), testVersion.getMajor(),
-                testVersion.getMinor(), testVersion.getRevision(), "Beta", Hashing.EMPTY_HASH_CODE);
-        LauncherVersion releaseBuild = new LauncherVersion(testVersion.getReserved(), testVersion.getMajor(),
-                testVersion.getMinor(), testVersion.getRevision(), "Release", Hashing.EMPTY_HASH_CODE);
-        assertTrue(betaBuild.needsUpdate(releaseBuild));
-
-        // Test user has a release stream but a beta build comes out
-        assertFalse(releaseBuild.needsUpdate(betaBuild));
-
-        // Test newer Reserved - launcher dev version
-        assertFalse(testVersion.needsUpdate(new LauncherVersion(testVersion.getReserved() - 1, testVersion.getMajor(),
-                testVersion.getMinor(), testVersion.getRevision(), testVersion.getStream(),
+            // Test newer Minor - launcher dev version
+            assertFalse(version.needsUpdate(new LauncherVersion(version.getReserved(), version.getMajor(),
+                version.getMinor() - 1, version.getRevision(), version.getStream(),
                 Hashing.EMPTY_HASH_CODE)));
 
-        // Test newer Major - launcher dev version
-        assertFalse(testVersion.needsUpdate(new LauncherVersion(testVersion.getReserved(), testVersion.getMajor() - 1,
-                testVersion.getMinor(), testVersion.getRevision(), testVersion.getStream(),
+            // Test newer Revision - launcher dev version
+            assertFalse(version.needsUpdate(new LauncherVersion(version.getReserved(), version.getMajor(),
+                version.getMinor(), version.getRevision() - 1, version.getStream(),
                 Hashing.EMPTY_HASH_CODE)));
-
-        // Test newer Minor - launcher dev version
-        assertFalse(testVersion.needsUpdate(new LauncherVersion(testVersion.getReserved(), testVersion.getMajor(),
-                testVersion.getMinor() - 1, testVersion.getRevision(), testVersion.getStream(),
-                Hashing.EMPTY_HASH_CODE)));
-
-        // Test newer Revision - launcher dev version
-        assertFalse(testVersion.needsUpdate(new LauncherVersion(testVersion.getReserved(), testVersion.getMajor(),
-                testVersion.getMinor(), testVersion.getRevision() - 1, testVersion.getStream(),
-                Hashing.EMPTY_HASH_CODE)));
+        }
     }
 
 }


### PR DESCRIPTION
### Description of the Change

Implement semantic versioning.

Let this update proliferate *before* migrating over to semantic versioning.

### Testing

Added test cases for the current state.

### Related Issues

#555 
