### PR TITLE
bug: Fix executable on Windows by disabling minimize

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -238,13 +238,6 @@ tasks {
 
     shadowJar {
         archiveClassifier.set(null as String?) // type problem shenanigans
-        minimize {
-            exclude(dependency("org.apache.logging.log4j:.*:.*"))
-            exclude(dependency("com.formdev:.*:.*"))
-            exclude(dependency("com.github.jnr:.*:.*"))
-            exclude(dependency("com.github.hypfvieh:.*:.*"))
-            exclude(dependency("org.apache.commons:commons-compress:.*"))
-        }
 
         // these are included by dbus-java which is only used on Linux
         exclude("jni/x86_64-Windows/")


### PR DESCRIPTION
### Description of the Change

Minimize seems to have been broken for a while.
In commit 03603122,
 InteliJ states that "dependency" argument type cannot be inferred.
Possible that "dependency" is completely different in KTS,
 but I doubt it.

### Testing

- @RedLime confirms that it works for them
- Running build