### PR TITLE
Console UTF-8 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This changelog only contains the changes that are unreleased. For changes for in
 - Always show Java path in main settings tab and when instance doesn't use a runtime
 - Issue with Quilt exported CurseForge packs not importing
 - Issue with mod images not being scaled smoothly [#731]
+- Fix UTF-8 support in ATLauncher console [#722]
 
 ### Misc
 - Add `xrandr` as a dependency for RPM [#691]

--- a/src/main/java/com/atlauncher/gui/LauncherConsole.java
+++ b/src/main/java/com/atlauncher/gui/LauncherConsole.java
@@ -27,6 +27,7 @@ import java.awt.event.ComponentAdapter;
 import java.awt.event.ComponentEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
+import java.nio.charset.StandardCharsets;
 
 import javax.swing.JFrame;
 import javax.swing.JMenuItem;
@@ -138,13 +139,14 @@ public class LauncherConsole extends JFrame implements RelocalizationListener {
         });
     }
 
+
     /**
      * Returns a string with the text currently in the console
      *
      * @return String Console Text
      */
     public String getLog() {
-        return console.getText();
+        return new String(console.getText().getBytes(),StandardCharsets.UTF_8);
     }
 
     public void showKillMinecraft() {


### PR DESCRIPTION
Need Test
Launcher self-test fail and crash

### Description of the Change

Support UTF-8 in console

### Testing

After testing, Chinese can be displayed normally at startup. But it crashes for unknown reasons, sometimes it doesn't. Suspected to be a local environment problem. please test again.

### Related Issues

#722 
