### PR TITLE
Implement JavaFX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This changelog only contains the changes that are unreleased. For changes for in
 ## 3.4.35.5
 
 ### New Features
+- Basic migration to JavaFX application
 
 ### Fixes
 

--- a/build.gradle
+++ b/build.gradle
@@ -29,15 +29,21 @@ plugins {
     id 'com.github.johnrengelman.shadow' version '8.1.1'
     id 'com.github.ben-manes.versions' version '0.47.0'
     id 'com.apollographql.apollo' version '2.5.14'
+    id "org.openjfx.javafxplugin" version "0.0.13"
 }
 
 apply plugin: 'org.mini2Dx.gettext'
 
-sourceCompatibility = '1.8'
-targetCompatibility = '1.8'
+sourceCompatibility = JavaVersion.VERSION_17
+targetCompatibility = JavaVersion.VERSION_17
 
 group = 'com.atlauncher'
 version = rootProject.file('src/main/resources/version').text.trim().replace('.Beta', '')
+
+javafx {
+    version = "17"
+    modules = [ 'javafx.controls', 'javafx.fxml', 'javafx.swing' ]
+}
 
 repositories {
     mavenCentral()

--- a/src/main/java/com/atlauncher/Launcher.java
+++ b/src/main/java/com/atlauncher/Launcher.java
@@ -82,6 +82,7 @@ public class Launcher {
     private List<DownloadableFile> launcherFiles; // Files the Launcher needs to download
 
     // UI things
+    @Deprecated
     private JFrame parent; // Parent JFrame of the actual Launcher
     private NewsTab newsPanel; // The news panel
     private PacksBrowserTab packsBrowserPanel; // The packs browser panel
@@ -361,7 +362,7 @@ public class Launcher {
     }
 
     public void reloadLauncherData() {
-        final JDialog dialog = new JDialog(this.parent, ModalityType.DOCUMENT_MODAL);
+        final JDialog dialog = new JDialog();
         dialog.setSize(300, 100);
         dialog.setTitle("Updating Launcher");
         dialog.setLocationRelativeTo(App.launcher.getParent());
@@ -431,6 +432,7 @@ public class Launcher {
      *
      * @param parent The Launcher main JFrame
      */
+    @Deprecated
     public void setParentFrame(JFrame parent) {
         this.parent = parent;
     }

--- a/src/main/java/com/atlauncher/gui/LauncherFrame.java
+++ b/src/main/java/com/atlauncher/gui/LauncherFrame.java
@@ -58,28 +58,25 @@ import com.atlauncher.managers.LogManager;
 import com.atlauncher.managers.PackManager;
 import com.atlauncher.managers.PerformanceManager;
 import com.atlauncher.network.Analytics;
-import com.atlauncher.utils.Utils;
+import javafx.embed.swing.SwingNode;
 
 @SuppressWarnings("serial")
-public final class LauncherFrame extends JFrame implements RelocalizationListener {
+public final class LauncherFrame extends JPanel implements RelocalizationListener {
     public JTabbedPane tabbedPane;
 
     private Map<Integer, Tab> tabs = new HashMap<>();
 
-    public LauncherFrame(boolean show) {
+    public LauncherFrame(final SwingNode swingNode, boolean show) {
         LogManager.info("Launcher opening");
         LogManager.info("Made By Bob*");
         LogManager.info("*(Not Actually)");
 
-        App.launcher.setParentFrame(this);
-        setTitle(Constants.LAUNCHER_NAME);
-        setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
-        setResizable(true);
+//        App.launcher.setParentFrame(this);
+//        setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
         setLayout(new BorderLayout());
-        setIconImage(Utils.getImage("/assets/image/icon.png"));
 
         setMinimumSize(new Dimension(1200, 700));
-        setLocationRelativeTo(null);
+  //      setLocationRelativeTo(null);
 
         try {
             if (App.settings.rememberWindowSizePosition && App.settings.launcherSize != null) {
@@ -106,19 +103,7 @@ public final class LauncherFrame extends JFrame implements RelocalizationListene
 
         if (show) {
             LogManager.info("Showing Launcher");
-            setVisible(true);
-
-            addWindowListener(new WindowAdapter() {
-                @Override
-                public void windowClosing(WindowEvent windowEvent) {
-                    try {
-                        if (SystemTray.isSupported()) {
-                            SystemTray.getSystemTray().remove(App.trayIcon);
-                        }
-                    } catch (Exception ignored) {
-                    }
-                }
-            });
+            swingNode.setContent(this);
         }
 
         RelocalizationManager.addListener(this);

--- a/src/main/java/com/atlauncher/utils/Utils.java
+++ b/src/main/java/com/atlauncher/utils/Utils.java
@@ -167,7 +167,7 @@ public class Utils {
         return new ImageIcon(file.getAbsolutePath());
     }
 
-    public static BufferedImage getImage(String img) {
+    public static InputStream getImageStream(String img){
         String name;
         if (!img.startsWith("/assets/image/")) {
             name = "/assets/image/" + img;
@@ -184,6 +184,13 @@ public class Utils {
         if (stream == null) {
             throw new NullPointerException("Stream == null");
         }
+
+        return stream;
+    }
+
+    public static BufferedImage getImage(String img) {
+        InputStream stream = getImageStream(img);
+
 
         try {
             return ImageIO.read(stream);


### PR DESCRIPTION
### Description of the Change
Begins the migration to JavaFX as swing is long dead.

Issues with this commit:
- Requires bump to Java 17.
- EXIT_ON_CLOSE replaced with a semi-tested alternative.
- setLocationRelativeTo has unknown replacement.
- setParentFrame is no longer possible currently, so reloadLauncherData does not work as expected.
- Current profiles to run launcher via "Launch" does not work, must use gradle "run".
- Requires javafx runtime library installed on host. Unknown windows status.

### Testing

- [ ] TBD