### PR TITLE
misc: Use FileChooserDialog in InstanceExportDialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,4 @@ This changelog only contains the changes that are unreleased. For changes for in
 - Duplicate Java arguments getting removed [#787]
 
 ### Misc
+- Use FileChooserDialog in InstanceExportDialog [#791]

--- a/src/main/java/com/atlauncher/dbus/DBusUtils.java
+++ b/src/main/java/com/atlauncher/dbus/DBusUtils.java
@@ -39,6 +39,10 @@ import org.freedesktop.dbus.types.Variant;
 
 public class DBusUtils {
     public static File[] selectFiles() {
+        return selectFiles(false);
+    }
+
+    public static File[] selectFiles(Boolean directory) {
         try {
             DBusConnection bus = DBusConnection.getConnection(DBusConnection.DBusBusType.SESSION);
 
@@ -82,7 +86,7 @@ public class DBusUtils {
                     "/org/freedesktop/portal/desktop", FileChooserInterface.class);
 
             Map<String, Variant> options = new HashMap<>();
-            options.put("directory", new Variant(Boolean.FALSE));
+            options.put("directory", new Variant(directory));
             options.put("handle_token", new Variant(token));
 
             fileChooserInterface.OpenFile("", "Pick File", options);

--- a/src/main/java/com/atlauncher/gui/dialogs/InstanceExportDialog.java
+++ b/src/main/java/com/atlauncher/gui/dialogs/InstanceExportDialog.java
@@ -195,24 +195,39 @@ public class InstanceExportDialog extends JDialog {
 
         final JTextField saveTo = new JTextField(25);
         saveTo.setText(Optional.ofNullable(instance.launcher.lastExportSaveTo)
-                .orElse(instance.getRoot().toAbsolutePath().toString()));
+            .orElse(instance.getRoot().toAbsolutePath().toString()));
+
+        // Disable manual input on flatpak (require proper xdg selection)
+        saveTo.setEnabled(!OS.isUsingFlatpak());
 
         JButton browseButton = new JButton(GetText.tr("Browse"));
         browseButton.addActionListener(e -> {
-            JFileChooser chooser = new JFileChooser();
-            chooser.setCurrentDirectory(new File(saveTo.getText()));
-            chooser.setDialogTitle(GetText.tr("Select path to save to"));
-            chooser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
-            chooser.setAcceptAllFileFilterUsed(false);
+            FileChooserDialog fcd = new FileChooserDialog(this,
+                GetText.tr("Select export directory"),
+                GetText.tr("Directory"),
+                GetText.tr("Select"));
 
-            if (chooser.showOpenDialog(null) == JFileChooser.APPROVE_OPTION) {
-                saveTo.setText(chooser.getSelectedFile().getAbsolutePath());
+            if (fcd.wasClosed()) {
+                return;
             }
+
+            List<File> files = fcd.getChosenFiles();
+
+            if (files != null && !files.isEmpty()) {
+                File dir = files.get(0);
+                saveTo.setText(dir.getAbsolutePath());
+            }
+        });
+
+        JButton resetButton = new JButton(GetText.tr("Reset"));
+        resetButton.addActionListener(e -> {
+            saveTo.setText(instance.getRoot().toAbsolutePath().toString());
         });
 
         saveToPanel.add(saveTo);
         saveToPanel.add(Box.createHorizontalStrut(5));
         saveToPanel.add(browseButton);
+        saveToPanel.add(resetButton);
 
         topPanel.add(saveToPanel, gbc);
 


### PR DESCRIPTION
### Description of the Change

JFileChooser does not have freedesktop portal support. 
By offloading work on FileChooserDialog we can have proper support. 
DBusUtils and FileChooserDialog were modified for directory support.

### Testing

- [ ] Windows
- [ ] MacOS
- [x] Linux Native
- [x] Linux Flatpak (Emulated via OS.java modification)

### Related Issues

Closes #790
