### PR TITLE
fix: Make HierarchyPanel intercept Relocalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This changelog only contains the changes that are unreleased. For changes for in
 - Issue installing 1.20.2 versions of NeoForge
 - Instance name/description not resetting after a successful install
 - Issues with non English regions and number formatting to api's/logs
+- Make HierarchyPanel intercept Relocalization [#836]
 
 ### Misc
 - Convert ConsoleOpenManager and ConsoleCloseManager into ConsoleStateManager [#814]

--- a/src/main/java/com/atlauncher/gui/panels/HierarchyPanel.java
+++ b/src/main/java/com/atlauncher/gui/panels/HierarchyPanel.java
@@ -23,6 +23,8 @@ import java.awt.event.HierarchyListener;
 
 import javax.swing.JPanel;
 
+import com.atlauncher.evnt.listener.RelocalizationListener;
+import com.atlauncher.evnt.manager.RelocalizationManager;
 import com.atlauncher.managers.LogManager;
 
 /**
@@ -42,6 +44,21 @@ public abstract class HierarchyPanel extends JPanel implements HierarchyListener
         super(layout);
         addNotify();
         addHierarchyListener(this);
+
+        // If the child is a child of RelocalizationListener
+        // We can handle relocalization for them
+        if (this instanceof RelocalizationListener) {
+            RelocalizationManager.addListener(this::tryReLocalization);
+        }
+    }
+
+    /**
+     * Will only re-localize the view if it is showing.
+     */
+    private void tryReLocalization() {
+        if (isShowing()) {
+            ((RelocalizationListener) this).onRelocalization();
+        }
     }
 
     @Override


### PR DESCRIPTION
### Description of the Change

`onRelocalization` can occur when a view is not visible. This will lead to NPEs.

Instead of the child directly adding itself to RelocalizationManager,
 we can instead have the HierarchyPanel handle that.
So relocalization can occur if the UI is visible.

### Testing

Modified NewsTab to inherit RelocalizationListener.
Found that the HierarchyPanel did its job.

### Related Issues

Should occur before #815, #816, #835