### PR TITLE
Fix NPE in Update Managers due to concurrency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,5 +8,6 @@ This changelog only contains the changes that are unreleased. For changes for in
 ### New Features
 
 ### Fixes
+- NPE in Update Managers due to concurrency
 
 ### Misc

--- a/src/main/java/com/atlauncher/managers/CurseForgeUpdateManager.java
+++ b/src/main/java/com/atlauncher/managers/CurseForgeUpdateManager.java
@@ -18,10 +18,10 @@
 package com.atlauncher.managers;
 
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
 import com.atlauncher.App;
 import com.atlauncher.data.Instance;
@@ -37,7 +37,7 @@ public class CurseForgeUpdateManager {
      * CurseForge instance update checking
      */
     private static final Map<UUID, BehaviorSubject<Optional<CurseForgeFile>>>
-        CURSEFORGE_INSTANCE_LATEST_VERSION = new HashMap<>();
+        CURSEFORGE_INSTANCE_LATEST_VERSION = new ConcurrentHashMap<>();
 
     /**
      * Get the update behavior subject for a given instance.

--- a/src/main/java/com/atlauncher/managers/ModpacksChUpdateManager.java
+++ b/src/main/java/com/atlauncher/managers/ModpacksChUpdateManager.java
@@ -18,11 +18,11 @@
 package com.atlauncher.managers;
 
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
 import com.atlauncher.constants.Constants;
@@ -38,7 +38,8 @@ public class ModpacksChUpdateManager {
     /**
      * Modpacks.ch instance update checking
      */
-    private static final Map<UUID, BehaviorSubject<Optional<ModpacksChPackVersion>>> MODPACKS_CH_INSTANCE_LATEST_VERSION = new HashMap<>();
+    private static final Map<UUID, BehaviorSubject<Optional<ModpacksChPackVersion>>>
+        MODPACKS_CH_INSTANCE_LATEST_VERSION = new ConcurrentHashMap<>();
 
     /**
      * Get the update behavior subject for a given instance.
@@ -57,7 +58,7 @@ public class ModpacksChUpdateManager {
      * Get an observable for an instances update.
      * <p>
      * Please do not cast to a behavior subject.
-     * 
+     *
      * @param instance Instance to get an observable for
      * @return Update observable
      */
@@ -67,7 +68,7 @@ public class ModpacksChUpdateManager {
 
     /**
      * Get the latest version of an instance
-     * 
+     *
      * @param instance Instance to get version of
      * @return Latest version, or null if no newer version is found
      */

--- a/src/main/java/com/atlauncher/managers/ModrinthModpackUpdateManager.java
+++ b/src/main/java/com/atlauncher/managers/ModrinthModpackUpdateManager.java
@@ -18,11 +18,11 @@
 package com.atlauncher.managers;
 
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
 import com.atlauncher.data.Instance;
 import com.atlauncher.data.modrinth.ModrinthVersion;
@@ -36,7 +36,7 @@ public class ModrinthModpackUpdateManager {
      * Modrinth instance update checking
      */
     private static final Map<UUID, BehaviorSubject<Optional<ModrinthVersion>>>
-        MODRINTH_INSTANCE_LATEST_VERSION = new HashMap<>();
+        MODRINTH_INSTANCE_LATEST_VERSION = new ConcurrentHashMap<>();
 
     /**
      * Get the update behavior subject for a given instance.

--- a/src/main/java/com/atlauncher/managers/TechnicModpackUpdateManager.java
+++ b/src/main/java/com/atlauncher/managers/TechnicModpackUpdateManager.java
@@ -18,10 +18,10 @@
 package com.atlauncher.managers;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
 import com.atlauncher.Gsons;
 import com.atlauncher.data.Instance;
@@ -39,13 +39,13 @@ public class TechnicModpackUpdateManager {
      * Technic Non Solder instance update checking
      */
     private static final Map<UUID, BehaviorSubject<Optional<TechnicModpack>>>
-        TECHNIC_INSTANCE_LATEST_VERSION = new HashMap<>();
+        TECHNIC_INSTANCE_LATEST_VERSION = new ConcurrentHashMap<>();
 
     /**
      * Technic Solder instance update checking
      */
     private static final Map<UUID, BehaviorSubject<Optional<TechnicSolderModpack>>>
-        TECHNIC_SOLDER_INSTANCE_LATEST_VERSION = new HashMap<>();
+        TECHNIC_SOLDER_INSTANCE_LATEST_VERSION = new ConcurrentHashMap<>();
 
     /**
      * Get the update behavior subject for a given instance.


### PR DESCRIPTION
### Description of the Change

This seems to occur with large libraries.

NPE due to multiple simultaneous calls to the update manager.

### Testing

- [x] Open / Close Launcher 10 times
- [x] Update All Instances
- [x] Remove an Instance