### PR TITLE
fixes: NPE by NewsTab.reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,5 +8,6 @@ This changelog only contains the changes that are unreleased. For changes for in
 ### New Features
 
 ### Fixes
+- NPE by NewsTab.reload
 
 ### Misc

--- a/src/main/java/com/atlauncher/gui/tabs/news/NewsTab.java
+++ b/src/main/java/com/atlauncher/gui/tabs/news/NewsTab.java
@@ -152,7 +152,8 @@ public class NewsTab extends HierarchyPanel implements Tab {
      * Reloads the panel with updated news.
      */
     public void reload() {
-        viewModel.reload();
+        if (viewModel != null)
+            viewModel.reload();
     }
 
     @Override


### PR DESCRIPTION
### Description of the Change

Quickly fixes NPE by NewsTab.reload

Underlying data process issue will persist.
An overhaul to NewsManager should be done to accommodate for this.

### Testing

- [x] Tried to cause an NPE
- [x] Opened launcher

### Related Issues

#856 