### PR TITLE
Restructure News Stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,4 @@ This changelog only contains the changes that are unreleased. For changes for in
 - Migrate to the new Gradle version catalogs for libraries and plugins
 - Update the `application.yml` GitHub workflow [#889]
 - Migrate to Gradle KTS [#898]
+- Refactor News stack

--- a/src/main/java/com/atlauncher/Data.java
+++ b/src/main/java/com/atlauncher/Data.java
@@ -23,9 +23,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.atlauncher.data.LWJGLVersions;
-import com.atlauncher.data.News;
 import com.atlauncher.data.Pack;
-import com.atlauncher.data.Server;
 import com.atlauncher.data.minecraft.JavaRuntimes;
 import com.atlauncher.data.minecraft.VersionManifestVersion;
 
@@ -33,8 +31,6 @@ public final class Data {
 
     public static Map<String, Object> CONFIG = new HashMap<>();
     public static Map<String, Object> CONFIG_OVERRIDES = new HashMap<>();
-
-    public static final List<News> NEWS = new LinkedList<>();
 
     public static final List<Pack> PACKS = new LinkedList<>();
 

--- a/src/main/java/com/atlauncher/Launcher.java
+++ b/src/main/java/com/atlauncher/Launcher.java
@@ -47,7 +47,6 @@ import com.atlauncher.graphql.type.AddLauncherLaunchInput;
 import com.atlauncher.graphql.type.LauncherJavaVersionInput;
 import com.atlauncher.gui.dialogs.ProgressDialog;
 import com.atlauncher.gui.tabs.PacksBrowserTab;
-import com.atlauncher.gui.tabs.news.NewsTab;
 import com.atlauncher.managers.AccountManager;
 import com.atlauncher.managers.ConfigManager;
 import com.atlauncher.managers.CurseForgeUpdateManager;
@@ -82,7 +81,6 @@ public class Launcher {
 
     // UI things
     private JFrame parent; // Parent JFrame of the actual Launcher
-    private NewsTab newsPanel; // The news panel
     private PacksBrowserTab packsBrowserPanel; // The packs browser panel
 
     // Update thread
@@ -454,15 +452,6 @@ public class Launcher {
      */
     public void setPacksBrowserPanel(PacksBrowserTab packsBrowserPanel) {
         this.packsBrowserPanel = packsBrowserPanel;
-    }
-
-    /**
-     * Sets the panel used for News
-     *
-     * @param newsPanel News Panel
-     */
-    public void setNewsPanel(NewsTab newsPanel) {
-        this.newsPanel = newsPanel;
     }
 
     /**

--- a/src/main/java/com/atlauncher/Launcher.java
+++ b/src/main/java/com/atlauncher/Launcher.java
@@ -100,7 +100,7 @@ public class Launcher {
 
         ConfigManager.loadConfig(); // Load the config
 
-        NewsManager.loadFileNews(); // Load the news
+        NewsManager.loadNews(); // Load the news
 
         if (App.settings.enableAnalytics && ConfigManager.getConfigItem("useGraphql.launcherLaunch", false) == true) {
             App.TASKPOOL.execute(() -> {
@@ -370,8 +370,7 @@ public class Launcher {
             checkForExternalPackUpdates();
 
             ConfigManager.loadConfig(); // Load the config
-            NewsManager.loadFileNews(); // Load the news
-            NewsManager.loadNetworkNews(); // Reload news panel
+            NewsManager.loadNews(); // Load the news
             PackManager.loadPacks(); // Load the Packs available in the Launcher
             reloadPacksBrowserPanel();// Reload packs browser panel
             PackManager.loadUsers(); // Load the Testers and Allowed Players for the packs

--- a/src/main/java/com/atlauncher/Launcher.java
+++ b/src/main/java/com/atlauncher/Launcher.java
@@ -102,7 +102,7 @@ public class Launcher {
 
         ConfigManager.loadConfig(); // Load the config
 
-        NewsManager.loadNews(); // Load the news
+        NewsManager.loadFileNews(); // Load the news
 
         if (App.settings.enableAnalytics && ConfigManager.getConfigItem("useGraphql.launcherLaunch", false) == true) {
             App.TASKPOOL.execute(() -> {
@@ -372,8 +372,8 @@ public class Launcher {
             checkForExternalPackUpdates();
 
             ConfigManager.loadConfig(); // Load the config
-            NewsManager.loadNews(); // Load the news
-            reloadNewsPanel(); // Reload news panel
+            NewsManager.loadFileNews(); // Load the news
+            NewsManager.loadNetworkNews(); // Reload news panel
             PackManager.loadPacks(); // Load the Packs available in the Launcher
             reloadPacksBrowserPanel();// Reload packs browser panel
             PackManager.loadUsers(); // Load the Testers and Allowed Players for the packs
@@ -463,13 +463,6 @@ public class Launcher {
      */
     public void setNewsPanel(NewsTab newsPanel) {
         this.newsPanel = newsPanel;
-    }
-
-    /**
-     * Reloads the panel used for News
-     */
-    public void reloadNewsPanel() {
-        this.newsPanel.reload(); // Reload the news panel
     }
 
     /**

--- a/src/main/java/com/atlauncher/data/AbstractNews.java
+++ b/src/main/java/com/atlauncher/data/AbstractNews.java
@@ -1,0 +1,63 @@
+/*
+ * ATLauncher - https://github.com/ATLauncher/ATLauncher
+ * Copyright (C) 2013-2022 ATLauncher
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.atlauncher.data;
+
+import java.text.SimpleDateFormat;
+
+import com.atlauncher.App;
+import com.atlauncher.graphql.GetNewsQuery.GeneralNew;
+
+/**
+ * Because there are two types of news in ATLauncher, but are used for the same purpose, this is a combing class.
+ *
+ * @since 2023 / 12 / 02
+ */
+public class AbstractNews {
+
+    /**
+     * HTML row entry
+     */
+    public final String htmlEntry;
+
+    /**
+     * Source object, just in case you want to use it.
+     */
+    public final Object source;
+
+    /**
+     * Create from {@link News}
+     *
+     * @param fileNews Old file json news
+     */
+    public AbstractNews(News fileNews) {
+        source = fileNews;
+        htmlEntry = fileNews.getHTML();
+    }
+
+    /**
+     * Create from {@link GeneralNew}
+     *
+     * @param networkNews GraphQL network result
+     */
+    public AbstractNews(GeneralNew networkNews) {
+        final SimpleDateFormat formatter = new SimpleDateFormat(App.settings.dateFormat + " HH:mm:ss a");
+        source = networkNews;
+        htmlEntry = "<h2>" + networkNews.title() + " (" + formatter.format(networkNews.createdAt()) + ")</h2>" + "<p>"
+            + networkNews.content() + "</p>";
+    }
+}

--- a/src/main/java/com/atlauncher/gui/LauncherFrame.java
+++ b/src/main/java/com/atlauncher/gui/LauncherFrame.java
@@ -170,7 +170,6 @@ public final class LauncherFrame extends JFrame implements RelocalizationListene
         PerformanceManager.start("newsTab");
         NewsTab newsTab = new NewsTab();
         this.tabs.put(UIConstants.LAUNCHER_NEWS_TAB, newsTab);
-        App.launcher.setNewsPanel(newsTab);
         PerformanceManager.end("newsTab");
 
         PerformanceManager.start("createPackTab");

--- a/src/main/java/com/atlauncher/gui/tabs/news/NewsTab.java
+++ b/src/main/java/com/atlauncher/gui/tabs/news/NewsTab.java
@@ -45,7 +45,6 @@ import com.atlauncher.viewmodel.impl.NewsViewModel;
  * This class extends {@link JPanel} and provides a Panel for displaying the
  * latest news.
  */
-@SuppressWarnings("serial")
 public class NewsTab extends HierarchyPanel implements Tab {
     private HTMLEditorKit NEWS_KIT;
     private ContextMenu NEWS_MENU;
@@ -86,7 +85,6 @@ public class NewsTab extends HierarchyPanel implements Tab {
             this.NEWS_PANE.setText(html);
             this.NEWS_PANE.setCaretPosition(0);
         }));
-        reload();
     }
 
     @Override
@@ -139,14 +137,6 @@ public class NewsTab extends HierarchyPanel implements Tab {
                 });
             }
         };
-    }
-
-    /**
-     * Reloads the panel with updated news.
-     */
-    public void reload() {
-        if (viewModel != null)
-            viewModel.reload();
     }
 
     @Override

--- a/src/main/java/com/atlauncher/gui/tabs/news/NewsTab.java
+++ b/src/main/java/com/atlauncher/gui/tabs/news/NewsTab.java
@@ -33,12 +33,10 @@ import javax.swing.event.HyperlinkEvent;
 import javax.swing.text.html.HTMLEditorKit;
 import javax.swing.text.html.StyleSheet;
 
-import org.apache.logging.log4j.Logger;
 import org.mini2Dx.gettext.GetText;
 
 import com.atlauncher.gui.panels.HierarchyPanel;
 import com.atlauncher.gui.tabs.Tab;
-import com.atlauncher.managers.LogManager;
 import com.atlauncher.utils.OS;
 import com.atlauncher.viewmodel.base.INewsViewModel;
 import com.atlauncher.viewmodel.impl.NewsViewModel;
@@ -83,15 +81,11 @@ public class NewsTab extends HierarchyPanel implements Tab {
         scrollPane.getVerticalScrollBar().setUnitIncrement(16);
         this.add(scrollPane, BorderLayout.CENTER);
 
-        viewModel.addOnReloadListener(html -> {
-            // Because reload() is a public function, we need to ensure it
-            // does not trigger setting the UI when the UI is hidden
-            if (isShowing()) {
-                this.NEWS_PANE.setText("");
-                this.NEWS_PANE.setText(html);
-                this.NEWS_PANE.setCaretPosition(0);
-            }
-        });
+        addDisposable(viewModel.getNewsHTML().subscribe(html -> {
+            this.NEWS_PANE.setText("");
+            this.NEWS_PANE.setText(html);
+            this.NEWS_PANE.setCaretPosition(0);
+        }));
         reload();
     }
 
@@ -101,7 +95,6 @@ public class NewsTab extends HierarchyPanel implements Tab {
         NEWS_MENU = null;
         NEWS_PANE = null;
         removeAll();
-        viewModel.addOnReloadListener(null);
     }
 
     private void createNewsKit() {

--- a/src/main/java/com/atlauncher/managers/NewsManager.java
+++ b/src/main/java/com/atlauncher/managers/NewsManager.java
@@ -69,44 +69,4 @@ public class NewsManager {
         LogManager.debug("Finished loading news");
         PerformanceManager.end();
     }
-
-    /**
-     * Get the News for the Launcher in HTML for display on the news panel.
-     *
-     * @return The HTML for displaying on the News Panel
-     */
-    public static String getNewsHTML() {
-        StringBuilder news = new StringBuilder("<html>");
-
-        for (News newsItem : Data.NEWS) {
-            news.append(newsItem.getHTML()).append("<hr/>");
-        }
-
-        // remove the last <hr/>
-        news = new StringBuilder(news.substring(0, news.length() - 5));
-        news.append("</html>");
-
-        return news.toString();
-    }
-
-    /**
-     * Takes a list of news items from GraphQL query and transforms into HTML.
-     *
-     * @return The HTML for displaying on the News Panel
-     */
-    public static String getNewsHTML(List<GetNewsQuery.GeneralNew> newsItems) {
-        StringBuilder news = new StringBuilder("<html>");
-        SimpleDateFormat formatter = new SimpleDateFormat(App.settings.dateFormat + " HH:mm:ss a");
-
-        for (GetNewsQuery.GeneralNew newsItem : newsItems) {
-            news.append("<h2>" + newsItem.title() + " (" + formatter.format(newsItem.createdAt()) + ")</h2>" + "<p>"
-                    + newsItem.content() + "</p><hr/>");
-        }
-
-        // remove the last <hr/>
-        news = new StringBuilder(news.substring(0, news.length() - 5));
-        news.append("</html>");
-
-        return news.toString();
-    }
 }

--- a/src/main/java/com/atlauncher/managers/NewsManager.java
+++ b/src/main/java/com/atlauncher/managers/NewsManager.java
@@ -23,50 +23,92 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
-import java.text.SimpleDateFormat;
+import java.nio.file.Files;
+import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
-import com.atlauncher.App;
-import com.atlauncher.Data;
+import org.jetbrains.annotations.NotNull;
+
+import com.apollographql.apollo.ApolloCall;
+import com.apollographql.apollo.api.Response;
+import com.apollographql.apollo.api.cache.http.HttpCachePolicy;
+import com.apollographql.apollo.exception.ApolloException;
 import com.atlauncher.FileSystem;
 import com.atlauncher.Gsons;
+import com.atlauncher.data.AbstractNews;
 import com.atlauncher.data.News;
 import com.atlauncher.graphql.GetNewsQuery;
+import com.atlauncher.network.GraphqlClient;
 import com.google.gson.JsonIOException;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.reflect.TypeToken;
 
+import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.subjects.BehaviorSubject;
+
 public class NewsManager {
+    static final BehaviorSubject<List<AbstractNews>> NEWS =
+        BehaviorSubject.createDefault(Collections.emptyList());
 
     /**
      * Get the News for the Launcher
      *
      * @return The News items
      */
-    public static List<News> getNews() {
-        return Data.NEWS;
+    public static Observable<List<AbstractNews>> getNews() {
+        return NEWS;
     }
 
     /**
      * Loads the languages for use in the Launcher
      */
-    public static void loadNews() {
+    public static void loadFileNews() {
         PerformanceManager.start();
         LogManager.debug("Loading news");
-        Data.NEWS.clear();
         try {
             java.lang.reflect.Type type = new TypeToken<List<News>>() {
             }.getType();
             File fileDir = FileSystem.JSON.resolve("newnews.json").toFile();
             BufferedReader in = new BufferedReader(
-                    new InputStreamReader(new FileInputStream(fileDir), StandardCharsets.UTF_8));
+                new InputStreamReader(Files.newInputStream(fileDir.toPath()), StandardCharsets.UTF_8));
 
-            Data.NEWS.addAll(Gsons.DEFAULT.fromJson(in, type));
+            List<News> fileNews = Gsons.DEFAULT.fromJson(in, type);
             in.close();
+
+            // Map the [News] to [AbstractNews]
+            NEWS.onNext(fileNews.stream().map(AbstractNews::new).collect(Collectors.toList()));
         } catch (JsonIOException | JsonSyntaxException | IOException e) {
             LogManager.logStackTrace(e);
         }
         LogManager.debug("Finished loading news");
         PerformanceManager.end();
+    }
+
+    /**
+     * Attempt to load news from the network
+     */
+    public static void loadNetworkNews() {
+        if (ConfigManager.getConfigItem("useGraphql.news", false)) {
+            GraphqlClient.apolloClient.query(new GetNewsQuery(10))
+                .toBuilder()
+                .httpCachePolicy(new HttpCachePolicy.Policy(HttpCachePolicy.FetchStrategy.CACHE_FIRST, 30, TimeUnit.MINUTES, false))
+                .build()
+                .enqueue(new ApolloCall.Callback<GetNewsQuery.Data>() {
+                    @Override
+                    public void onResponse(@NotNull Response<GetNewsQuery.Data> response) {
+                        GetNewsQuery.Data data = response.getData();
+                        if (data == null) return;
+                        List<GetNewsQuery.GeneralNew> networkNews = data.generalNews();
+                        NEWS.onNext(networkNews.stream().map(AbstractNews::new).collect(Collectors.toList()));
+                    }
+
+                    @Override
+                    public void onFailure(@NotNull ApolloException e) {
+                        LogManager.logStackTrace("Error fetching news", e);
+                    }
+                });
+        }
     }
 }

--- a/src/main/java/com/atlauncher/viewmodel/base/INewsViewModel.java
+++ b/src/main/java/com/atlauncher/viewmodel/base/INewsViewModel.java
@@ -30,9 +30,4 @@ public interface INewsViewModel {
      * Observable of news HTML to display
      */
     Observable<String> getNewsHTML();
-
-    /**
-     * Reload news
-     */
-    void reload();
 }

--- a/src/main/java/com/atlauncher/viewmodel/base/INewsViewModel.java
+++ b/src/main/java/com/atlauncher/viewmodel/base/INewsViewModel.java
@@ -17,20 +17,19 @@
  */
 package com.atlauncher.viewmodel.base;
 
-import java.util.function.Consumer;
+import io.reactivex.rxjava3.core.Observable;
 
 /**
- * 14 / 06 / 2022
- *
  * View model for NewsTab
+ *
+ * @since 2022 / 06 / 14
  */
 public interface INewsViewModel {
 
     /**
-     * React to reload events
-     * @param onReload function to be called
+     * Observable of news HTML to display
      */
-    void addOnReloadListener(Consumer<String> onReload);
+    Observable<String> getNewsHTML();
 
     /**
      * Reload news


### PR DESCRIPTION
### Description of the Change

There are currently two ways to load news.
 From JSON and from GraphQL

Currently, Data.NEWS only handles json news, not graphql news.

This commit changes that.

InstanceManager now handles all news and their processes under
 AbstractNews.

This liberates NewsTab from being the middleman for loading news.

### Testing

- [x] Open Launcher
- [x] Run Launcher Tests
- [x] Run "Check for Updates" 

### Related Issues

#856 