### PR TITLE
fix: Ensure (Old) Instance is removed from Launcher during reinstall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,5 +9,6 @@ This changelog only contains the changes that are unreleased. For changes for in
 
 ### Fixes
 - NPE by NewsTab.reload
+- Ensure instance is created with a UUID
 
 ### Misc

--- a/src/main/java/com/atlauncher/workers/InstanceInstaller.java
+++ b/src/main/java/com/atlauncher/workers/InstanceInstaller.java
@@ -37,6 +37,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -2470,6 +2471,7 @@ public class InstanceInstaller extends SwingWorker<Boolean, Void> implements Net
 
         if (!this.isReinstall) {
             instanceLauncher = new InstanceLauncher();
+            instance.uuid = UUID.randomUUID();
         } else {
             instanceLauncher = this.instance.launcher;
             instance.uuid = this.instance.uuid;


### PR DESCRIPTION
### Description of the Change

One line wonder.

### Testing

- [x] Reinstall instance
- [x] Reinstall instance with different version
- [x] Ensure world files preserved

### Related Issues

Closes #859
