### PR TITLE
Update gradle-wrapper.properties to use Gradle 8.7 instead of 8.2

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
### Description of the Change

Newer versions of Gradle has more features, bug fixes and improvements (you can see [8.7 release notes](https://docs.gradle.org/current/release-notes.html) and the other changes from 8.3) and it's also deprecate new things we will get warnings that help the migration in order to be prepared for Gradle 9

### Testing

This change should not breaking anything, although I have not tested it yet, (because of my slow network, I can't fork the repo for now)

### Related Issues

None
