### PR TITLE
Update application.yml GitHub workflow

### DIFF
--- a/.github/workflows/application.yml
+++ b/.github/workflows/application.yml
@@ -18,7 +18,6 @@ jobs:
         with:
           distribution: "temurin"
           java-version: 8
-          #cache: "gradle" # See: https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#incompatibility-with-other-caching-mechanisms
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
@@ -45,7 +44,6 @@ jobs:
         with:
           distribution: "temurin"
           java-version: ${{ matrix.java-version }}
-          #cache: "gradle" # See: https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#incompatibility-with-other-caching-mechanisms
         
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
@@ -78,7 +76,6 @@ jobs:
         with:
           distribution: "temurin"
           java-version: ${{ matrix.java-version }}
-          #cache: "gradle" # See: https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#incompatibility-with-other-caching-mechanisms
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
@@ -103,7 +100,6 @@ jobs:
         with:
           distribution: "temurin"
           java-version: 8
-          #cache: "gradle" # See: https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#incompatibility-with-other-caching-mechanisms
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3

--- a/.github/workflows/application.yml
+++ b/.github/workflows/application.yml
@@ -9,15 +9,21 @@ concurrency:
 jobs:
   ci:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
 
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: "temurin"
           java-version: 8
-          cache: "gradle"
+          #cache: "gradle" # See: https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#incompatibility-with-other-caching-mechanisms
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+        with:
+            validate-wrappers: true
 
       - name: Check license headers
         run: ./gradlew checkLicenses
@@ -25,6 +31,7 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     needs: ci
+    timeout-minutes: 5
     strategy:
       matrix:
         java-version: ["8", "11", "17", "20"] # LTS + Latest
@@ -34,11 +41,16 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up JDK ${{ matrix.java-version }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: "temurin"
           java-version: ${{ matrix.java-version }}
-          cache: "gradle"
+          #cache: "gradle" # See: https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#incompatibility-with-other-caching-mechanisms
+        
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+        with:
+            validate-wrappers: true
 
       - name: Run Unit Tests
         run: ./gradlew --no-daemon test --tests com.atlauncher.*
@@ -52,6 +64,7 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     needs: ci
+    timeout-minutes: 5
     strategy:
       matrix:
         java-version: ["8", "11", "17", "20"] # LTS + Latest
@@ -61,11 +74,16 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up JDK ${{ matrix.java-version }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: "temurin"
           java-version: ${{ matrix.java-version }}
-          cache: "gradle"
+          #cache: "gradle" # See: https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#incompatibility-with-other-caching-mechanisms
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+        with:
+            validate-wrappers: true
 
       - name: Build
         run: ./gradlew build -x test
@@ -73,6 +91,7 @@ jobs:
   package:
     runs-on: ubuntu-latest
     needs: ci
+    timeout-minutes: 5
     outputs:
       version: ${{ steps.version.outputs.text }}
       clean-version: ${{ steps.clean-version.outputs.replaced }}
@@ -80,11 +99,16 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: "temurin"
           java-version: 8
-          cache: "gradle"
+          #cache: "gradle" # See: https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#incompatibility-with-other-caching-mechanisms
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+        with:
+            validate-wrappers: true
 
       - name: Read version
         id: version
@@ -113,6 +137,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: [test, build, package]
+    timeout-minutes: 5
     if: ${{ github.ref == 'refs/heads/master' && !endsWith(needs.package.outputs.version, '.Beta') }}
     permissions:
       contents: write


### PR DESCRIPTION
### Description of the Change

This PR improve the GitHub workflow a little:

1. Add timeout to avoid running the workflow forever because of infinite loop ( the default is 360 minutes )
2. Setup Gradle using `gradle/actions/setup-gradle` and depends on it's caching instead of `cache: gradle` from `actions/setup-java`
3. Validate Gradle Wrapper which is important for security, anyone can send a PR that change the jar file and then GitHub will test the PR with the updated workflow & Repository files, in order to get access to everything including the GitHub secrets, but if you are not careful you might even merge the PR because GitHub doesn't show large changes by Default, the attacker might include some malicious jar with the same file name so it will used by other developers who want to send PRs or build from source
4. Update `actions/setup-java` from v3 to v4

See this [link](https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#why-use-the-setup-gradle-action) for more info:

```markdown

Why use the setup-gradle action?

It is possible to directly invoke Gradle in your workflow, and the actions/setup-java@v4 action provides a simple way to cache Gradle dependencies.

However, the setup-gradle action offers a several advantages over this approach:

Easily [configure your workflow to use a specific version of Gradle](https://github.com/ATLauncher/ATLauncher/compare/master...ellet0:ATLauncher:patch-2#build-with-a-specific-gradle-version) using the gradle-version parameter. Gradle distributions are automatically downloaded and cached.
More sophisticated and more efficient caching of Gradle User Home between invocations, compared to setup-java and most custom configurations using actions/cache. [More details below](https://github.com/ATLauncher/ATLauncher/compare/master...ellet0:ATLauncher:patch-2#caching-build-state-between-jobs).
Detailed reporting of cache usage and cache configuration options allow you to [optimize the use of the GitHub actions cache](https://github.com/ATLauncher/ATLauncher/compare/master...ellet0:ATLauncher:patch-2#optimizing-cache-effectiveness).
[Generate and Submit a GitHub Dependency Graph](https://github.com/ATLauncher/ATLauncher/compare/master...ellet0:ATLauncher:patch-2#github-dependency-graph-support) for your project, enabling Dependabot security alerts.
[Automatic capture of Build Scan® links](https://github.com/ATLauncher/ATLauncher/compare/master...ellet0:ATLauncher:patch-2#build-reporting) from the build, making them easier to locate in workflow runs.
The setup-gradle action is designed to provide these benefits with minimal configuration. These features work both when Gradle is executed via setup-gradle and for any Gradle execution in subsequent steps.

```

### Testing

This change should be tested using Github action

### Related Issues

None