### PR TITLE
Feature/quick play to join a minecraft server, world and realm right after launching the game

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This changelog only contains the changes that are unreleased. For changes for in
 
 ### New Features
 
+1. Add the option to join a minecraft server when launching a instance [#893](https://github.com/ATLauncher/ATLauncher/pull/893)
+
 ### Fixes
 
 ### Misc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This changelog only contains the changes that are unreleased. For changes for in
 
 ### New Features
 
-- Add the option to join a minecraft server when launching a instance [#748]
+- Add the option to join a minecraft server, world, and realm when launching an instance [#748]
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This changelog only contains the changes that are unreleased. For changes for in
 
 ### New Features
 
-1. Add the option to join a minecraft server when launching a instance [#893](https://github.com/ATLauncher/ATLauncher/pull/893)
+- Add the option to join a minecraft server when launching a instance [#748]
 
 ### Fixes
 

--- a/src/main/java/com/atlauncher/constants/Constants.java
+++ b/src/main/java/com/atlauncher/constants/Constants.java
@@ -149,6 +149,7 @@ public class Constants {
             + "/mc/game/version_manifest.json";
     public static final String MINECRAFT_JAVA_RUNTIME_URL = LAUNCHER_META_MINECRAFT
             + "/v1/products/java-runtime/2ec0cc96c44e5a76b9c8b7c39df7210883d12871/all.json";
+    public static final int MINECRAFT_DEFAULT_SERVER_PORT = 25565;
 
     // Misc
     public static final String LEGACY_JAVA_FIXER_URL = "https://cdn.atlcdn.net/legacyjavafixer-1.0.jar";

--- a/src/main/java/com/atlauncher/data/Instance.java
+++ b/src/main/java/com/atlauncher/data/Instance.java
@@ -3240,6 +3240,27 @@ public class Instance extends MinecraftVersion {
         return Arrays.stream(folders).map(File::getName).collect(Collectors.toList());
     }
 
+    public boolean isQuickPlayMultiplayerSupported() {
+        return arguments.game.stream().anyMatch(
+            argumentRule -> argumentRule.value instanceof List &&
+                ((List<?>) argumentRule.value).contains("--quickPlayMultiplayer")
+        );
+    }
+
+    public boolean isQuickPlaySinglePlayerSupported() {
+        return arguments.game.stream().anyMatch(
+            argumentRule -> argumentRule.value instanceof List &&
+                ((List<?>) argumentRule.value).contains("--quickPlaySingleplayer")
+        );
+    }
+
+    public boolean isQuickPlayRealmsSupported() {
+        return arguments.game.stream().anyMatch(
+            argumentRule -> argumentRule.value instanceof List &&
+                ((List<?>) argumentRule.value).contains("--quickPlayRealms")
+        );
+    }
+
     private List<Path> getModPathsFromFilesystem() {
         return getModPathsFromFilesystem(Arrays.asList(ROOT.resolve("mods"),
                 ROOT.resolve("resourcepacks"),

--- a/src/main/java/com/atlauncher/data/Instance.java
+++ b/src/main/java/com/atlauncher/data/Instance.java
@@ -3234,6 +3234,12 @@ public class Instance extends MinecraftVersion {
         return launcher.version;
     }
 
+    public List<String> getSinglePlayerWorldNamesFromFilesystem() {
+        File[] folders = ROOT.resolve("saves").toFile().listFiles((dir, name) -> new File(dir, name).isDirectory());
+        if (folders == null) return new ArrayList<>();
+        return Arrays.stream(folders).map(File::getName).collect(Collectors.toList());
+    }
+
     private List<Path> getModPathsFromFilesystem() {
         return getModPathsFromFilesystem(Arrays.asList(ROOT.resolve("mods"),
                 ROOT.resolve("resourcepacks"),

--- a/src/main/java/com/atlauncher/data/Instance.java
+++ b/src/main/java/com/atlauncher/data/Instance.java
@@ -149,7 +149,6 @@ import com.atlauncher.managers.PerformanceManager;
 import com.atlauncher.managers.TechnicModpackUpdateManager;
 import com.atlauncher.mclauncher.MCLauncher;
 import com.atlauncher.network.Analytics;
-import com.atlauncher.network.Download;
 import com.atlauncher.network.DownloadPool;
 import com.atlauncher.network.GraphqlClient;
 import com.atlauncher.network.analytics.AnalyticsEvent;
@@ -438,7 +437,7 @@ public class Instance extends MinecraftVersion {
             VersionManifestVersion minecraftVersionManifest = MinecraftManager
                     .getMinecraftVersion(id);
 
-            Download download = Download.build()
+            com.atlauncher.network.Download download = com.atlauncher.network.Download.build()
                     .setUrl(minecraftVersionManifest.url).hash(minecraftVersionManifest.sha1)
                     .size(minecraftVersionManifest.size)
                     .downloadTo(FileSystem.MINECRAFT_VERSIONS_JSON.resolve(minecraftVersionManifest.id + ".json"))
@@ -459,7 +458,7 @@ public class Instance extends MinecraftVersion {
         PerformanceManager.start("Downloading Minecraft");
         try {
             progressDialog.setLabel(GetText.tr("Downloading Minecraft"));
-            Download clientDownload = Download.build()
+            com.atlauncher.network.Download clientDownload = com.atlauncher.network.Download.build()
                     .setUrl(this.downloads.client.url).hash(this.downloads.client.sha1).size(this.downloads.client.size)
                     .withHttpClient(httpClient).downloadTo(this.getMinecraftJarLibraryPath());
 
@@ -484,7 +483,7 @@ public class Instance extends MinecraftVersion {
 
                 LoggingFile loggingFile = logging.client.file;
 
-                Download loggerDownload = Download.build()
+                com.atlauncher.network.Download loggerDownload = com.atlauncher.network.Download.build()
                         .setUrl(loggingFile.url).hash(loggingFile.sha1)
                         .size(loggingFile.size).downloadTo(FileSystem.RESOURCES_LOG_CONFIGS.resolve(loggingFile.id))
                         .withHttpClient(httpClient);
@@ -536,7 +535,7 @@ public class Instance extends MinecraftVersion {
                         ? LWJGLManager.getReplacementLWJGL3Library(this, l)
                         : l)
                 .forEach(library -> {
-                    Download download = new Download()
+                    com.atlauncher.network.Download download = new com.atlauncher.network.Download()
                             .setUrl(library.downloads.artifact.url)
                             .downloadTo(FileSystem.LIBRARIES.resolve(library.downloads.artifact.path))
                             .hash(library.downloads.artifact.sha1).size(library.downloads.artifact.size)
@@ -552,7 +551,7 @@ public class Instance extends MinecraftVersion {
                 .forEach(library -> {
                     com.atlauncher.data.minecraft.Download download = library.getNativeDownloadForOS();
 
-                    librariesPool.add(new Download().setUrl(download.url)
+                    librariesPool.add(new com.atlauncher.network.Download().setUrl(download.url)
                             .downloadTo(FileSystem.LIBRARIES.resolve(download.path)).hash(download.sha1)
                             .size(download.size)
                             .withHttpClient(httpClient));
@@ -565,7 +564,7 @@ public class Instance extends MinecraftVersion {
 
             if (fmlLibraries != null) {
                 fmlLibraries.forEach((library) -> {
-                    Download download = new Download()
+                    com.atlauncher.network.Download download = new com.atlauncher.network.Download()
                             .setUrl(String.format("%s/fmllibs/%s", Constants.DOWNLOAD_SERVER, library.name))
                             .downloadTo(FileSystem.LIBRARIES.resolve("fmllib/" + library.name))
                             .copyTo(ROOT.resolve("lib/" + library.name)).hash(library.sha1Hash)
@@ -603,7 +602,7 @@ public class Instance extends MinecraftVersion {
                 JavaRuntime runtimeToDownload = runtimesForSystem.get(runtimeToUse).get(0);
 
                 try {
-                    JavaRuntimeManifest javaRuntimeManifest = Download.build()
+                    JavaRuntimeManifest javaRuntimeManifest = com.atlauncher.network.Download.build()
                             .setUrl(runtimeToDownload.manifest.url).size(runtimeToDownload.manifest.size)
                             .hash(runtimeToDownload.manifest.sha1).downloadTo(FileSystem.MINECRAFT_RUNTIMES
                                     .resolve(runtimeToUse).resolve("manifest.json"))
@@ -627,7 +626,7 @@ public class Instance extends MinecraftVersion {
                     // collect the files we need to download
                     javaRuntimeManifest.files.forEach((key, file) -> {
                         if (file.type == JavaRuntimeManifestFileType.FILE) {
-                            Download download = new Download()
+                            com.atlauncher.network.Download download = new com.atlauncher.network.Download()
                                     .setUrl(file.downloads.raw.url).downloadTo(runtimeDirectory.resolve(key))
                                     .hash(file.downloads.raw.sha1).size(file.downloads.raw.size)
                                     .executable(file.executable).withHttpClient(httpClient);
@@ -661,7 +660,7 @@ public class Instance extends MinecraftVersion {
         progressDialog.setLabel(GetText.tr("Organising Resources"));
         MojangAssetIndex assetIndex = this.assetIndex;
 
-        AssetIndex index = Download.build().setUrl(assetIndex.url).hash(assetIndex.sha1)
+        AssetIndex index = com.atlauncher.network.Download.build().setUrl(assetIndex.url).hash(assetIndex.sha1)
                 .size(assetIndex.size).downloadTo(FileSystem.RESOURCES_INDEXES.resolve(assetIndex.id + ".json"))
                 .withHttpClient(httpClient).asClass(AssetIndex.class);
 
@@ -671,7 +670,7 @@ public class Instance extends MinecraftVersion {
             String filename = object.hash.substring(0, 2) + "/" + object.hash;
             String url = String.format("%s/%s", Constants.MINECRAFT_RESOURCES, filename);
 
-            Download download = new Download().setUrl(url)
+            com.atlauncher.network.Download download = new com.atlauncher.network.Download().setUrl(url)
                     .downloadTo(FileSystem.RESOURCES_OBJECTS.resolve(filename)).hash(object.hash).size(object.size)
                     .withHttpClient(httpClient);
 
@@ -769,7 +768,7 @@ public class Instance extends MinecraftVersion {
             LWJGLLibrary library = LWJGLManager.getLegacyLWJGLLibrary();
 
             if (library != null) {
-                Download download = new Download().setUrl(library.url)
+                com.atlauncher.network.Download download = new com.atlauncher.network.Download().setUrl(library.url)
                         .downloadTo(FileSystem.LIBRARIES.resolve(library.path)).unzipTo(lwjglNativesTempDir)
                         .hash(library.sha1).size(library.size).withHttpClient(httpClient);
 
@@ -1508,7 +1507,7 @@ public class Instance extends MinecraftVersion {
                 FileUtils.copyFile(downloadLocation, finalLocation, true);
             }
         } else {
-            Download download = Download.build().setUrl(file.downloadUrl)
+            com.atlauncher.network.Download download = com.atlauncher.network.Download.build().setUrl(file.downloadUrl)
                     .downloadTo(downloadLocation).size(file.fileLength)
                     .withHttpClient(Network.createProgressClient(dialog));
 
@@ -1585,7 +1584,7 @@ public class Instance extends MinecraftVersion {
                 : (mod.projectType == ModrinthProjectType.SHADER
                         ? this.getRoot().resolve("shaderpacks").resolve(fileToDownload.filename)
                         : this.getRoot().resolve("resourcepacks").resolve(fileToDownload.filename));
-        Download download = Download.build().setUrl(fileToDownload.url)
+        com.atlauncher.network.Download download = com.atlauncher.network.Download.build().setUrl(fileToDownload.url)
                 .downloadTo(downloadLocation).copyTo(finalLocation)
                 .withHttpClient(Network.createProgressClient(dialog));
 
@@ -3295,10 +3294,10 @@ public class Instance extends MinecraftVersion {
                 continue;
             }
 
-            Type fileType = path.equals(ROOT.resolve("resourcepacks"))
-                    ? Type.resourcepack
-                    : (path.equals(ROOT.resolve("jarmods")) ? Type.jar
-                            : Type.mods);
+            com.atlauncher.data.Type fileType = path.equals(ROOT.resolve("resourcepacks"))
+                    ? com.atlauncher.data.Type.resourcepack
+                    : (path.equals(ROOT.resolve("jarmods")) ? com.atlauncher.data.Type.jar
+                            : com.atlauncher.data.Type.mods);
 
             try (Stream<Path> stream = Files.list(path)) {
                 files.addAll(stream
@@ -3319,10 +3318,10 @@ public class Instance extends MinecraftVersion {
             progressDialog.addThread(new Thread(() -> {
                 List<DisableableMod> mods = files.parallelStream()
                         .map(file -> {
-                            Type fileType = file.getParent().equals(ROOT.resolve("resourcepacks"))
-                                    ? Type.resourcepack
-                                    : (file.getParent().equals(ROOT.resolve("jarmods")) ? Type.jar
-                                            : Type.mods);
+                            com.atlauncher.data.Type fileType = file.getParent().equals(ROOT.resolve("resourcepacks"))
+                                    ? com.atlauncher.data.Type.resourcepack
+                                    : (file.getParent().equals(ROOT.resolve("jarmods")) ? com.atlauncher.data.Type.jar
+                                            : com.atlauncher.data.Type.mods);
 
                             return DisableableMod.generateMod(file.toFile(), fileType,
                                     !file.getParent().equals(ROOT.resolve("disabledmods")));
@@ -3461,7 +3460,7 @@ public class Instance extends MinecraftVersion {
         PerformanceManager.start("Instance::scanMissingMods - CheckForRemovedMods");
         // next remove any mods that the no longer exist in the filesystem
         List<DisableableMod> removedMods = launcher.mods.parallelStream().filter(mod -> {
-            if (!mod.wasSelected || mod.skipped || mod.type != Type.mods) {
+            if (!mod.wasSelected || mod.skipped || mod.type != com.atlauncher.data.Type.mods) {
                 return false;
             }
 
@@ -3484,7 +3483,7 @@ public class Instance extends MinecraftVersion {
         Set<File> seenModFiles = new HashSet<>();
         List<DisableableMod> duplicateMods = launcher.mods.stream()
                 .filter(mod -> {
-                    if (!mod.wasSelected || mod.skipped || mod.type != Type.mods) {
+                    if (!mod.wasSelected || mod.skipped || mod.type != com.atlauncher.data.Type.mods) {
                         return false;
                     }
 

--- a/src/main/java/com/atlauncher/data/Instance.java
+++ b/src/main/java/com/atlauncher/data/Instance.java
@@ -149,6 +149,7 @@ import com.atlauncher.managers.PerformanceManager;
 import com.atlauncher.managers.TechnicModpackUpdateManager;
 import com.atlauncher.mclauncher.MCLauncher;
 import com.atlauncher.network.Analytics;
+import com.atlauncher.network.Download;
 import com.atlauncher.network.DownloadPool;
 import com.atlauncher.network.GraphqlClient;
 import com.atlauncher.network.analytics.AnalyticsEvent;
@@ -437,7 +438,7 @@ public class Instance extends MinecraftVersion {
             VersionManifestVersion minecraftVersionManifest = MinecraftManager
                     .getMinecraftVersion(id);
 
-            com.atlauncher.network.Download download = com.atlauncher.network.Download.build()
+            Download download = Download.build()
                     .setUrl(minecraftVersionManifest.url).hash(minecraftVersionManifest.sha1)
                     .size(minecraftVersionManifest.size)
                     .downloadTo(FileSystem.MINECRAFT_VERSIONS_JSON.resolve(minecraftVersionManifest.id + ".json"))
@@ -458,7 +459,7 @@ public class Instance extends MinecraftVersion {
         PerformanceManager.start("Downloading Minecraft");
         try {
             progressDialog.setLabel(GetText.tr("Downloading Minecraft"));
-            com.atlauncher.network.Download clientDownload = com.atlauncher.network.Download.build()
+            Download clientDownload = Download.build()
                     .setUrl(this.downloads.client.url).hash(this.downloads.client.sha1).size(this.downloads.client.size)
                     .withHttpClient(httpClient).downloadTo(this.getMinecraftJarLibraryPath());
 
@@ -483,7 +484,7 @@ public class Instance extends MinecraftVersion {
 
                 LoggingFile loggingFile = logging.client.file;
 
-                com.atlauncher.network.Download loggerDownload = com.atlauncher.network.Download.build()
+                Download loggerDownload = Download.build()
                         .setUrl(loggingFile.url).hash(loggingFile.sha1)
                         .size(loggingFile.size).downloadTo(FileSystem.RESOURCES_LOG_CONFIGS.resolve(loggingFile.id))
                         .withHttpClient(httpClient);
@@ -535,7 +536,7 @@ public class Instance extends MinecraftVersion {
                         ? LWJGLManager.getReplacementLWJGL3Library(this, l)
                         : l)
                 .forEach(library -> {
-                    com.atlauncher.network.Download download = new com.atlauncher.network.Download()
+                    Download download = new Download()
                             .setUrl(library.downloads.artifact.url)
                             .downloadTo(FileSystem.LIBRARIES.resolve(library.downloads.artifact.path))
                             .hash(library.downloads.artifact.sha1).size(library.downloads.artifact.size)
@@ -551,7 +552,7 @@ public class Instance extends MinecraftVersion {
                 .forEach(library -> {
                     com.atlauncher.data.minecraft.Download download = library.getNativeDownloadForOS();
 
-                    librariesPool.add(new com.atlauncher.network.Download().setUrl(download.url)
+                    librariesPool.add(new Download().setUrl(download.url)
                             .downloadTo(FileSystem.LIBRARIES.resolve(download.path)).hash(download.sha1)
                             .size(download.size)
                             .withHttpClient(httpClient));
@@ -564,7 +565,7 @@ public class Instance extends MinecraftVersion {
 
             if (fmlLibraries != null) {
                 fmlLibraries.forEach((library) -> {
-                    com.atlauncher.network.Download download = new com.atlauncher.network.Download()
+                    Download download = new Download()
                             .setUrl(String.format("%s/fmllibs/%s", Constants.DOWNLOAD_SERVER, library.name))
                             .downloadTo(FileSystem.LIBRARIES.resolve("fmllib/" + library.name))
                             .copyTo(ROOT.resolve("lib/" + library.name)).hash(library.sha1Hash)
@@ -602,7 +603,7 @@ public class Instance extends MinecraftVersion {
                 JavaRuntime runtimeToDownload = runtimesForSystem.get(runtimeToUse).get(0);
 
                 try {
-                    JavaRuntimeManifest javaRuntimeManifest = com.atlauncher.network.Download.build()
+                    JavaRuntimeManifest javaRuntimeManifest = Download.build()
                             .setUrl(runtimeToDownload.manifest.url).size(runtimeToDownload.manifest.size)
                             .hash(runtimeToDownload.manifest.sha1).downloadTo(FileSystem.MINECRAFT_RUNTIMES
                                     .resolve(runtimeToUse).resolve("manifest.json"))
@@ -626,7 +627,7 @@ public class Instance extends MinecraftVersion {
                     // collect the files we need to download
                     javaRuntimeManifest.files.forEach((key, file) -> {
                         if (file.type == JavaRuntimeManifestFileType.FILE) {
-                            com.atlauncher.network.Download download = new com.atlauncher.network.Download()
+                            Download download = new Download()
                                     .setUrl(file.downloads.raw.url).downloadTo(runtimeDirectory.resolve(key))
                                     .hash(file.downloads.raw.sha1).size(file.downloads.raw.size)
                                     .executable(file.executable).withHttpClient(httpClient);
@@ -660,7 +661,7 @@ public class Instance extends MinecraftVersion {
         progressDialog.setLabel(GetText.tr("Organising Resources"));
         MojangAssetIndex assetIndex = this.assetIndex;
 
-        AssetIndex index = com.atlauncher.network.Download.build().setUrl(assetIndex.url).hash(assetIndex.sha1)
+        AssetIndex index = Download.build().setUrl(assetIndex.url).hash(assetIndex.sha1)
                 .size(assetIndex.size).downloadTo(FileSystem.RESOURCES_INDEXES.resolve(assetIndex.id + ".json"))
                 .withHttpClient(httpClient).asClass(AssetIndex.class);
 
@@ -670,7 +671,7 @@ public class Instance extends MinecraftVersion {
             String filename = object.hash.substring(0, 2) + "/" + object.hash;
             String url = String.format("%s/%s", Constants.MINECRAFT_RESOURCES, filename);
 
-            com.atlauncher.network.Download download = new com.atlauncher.network.Download().setUrl(url)
+            Download download = new Download().setUrl(url)
                     .downloadTo(FileSystem.RESOURCES_OBJECTS.resolve(filename)).hash(object.hash).size(object.size)
                     .withHttpClient(httpClient);
 
@@ -768,7 +769,7 @@ public class Instance extends MinecraftVersion {
             LWJGLLibrary library = LWJGLManager.getLegacyLWJGLLibrary();
 
             if (library != null) {
-                com.atlauncher.network.Download download = new com.atlauncher.network.Download().setUrl(library.url)
+                Download download = new Download().setUrl(library.url)
                         .downloadTo(FileSystem.LIBRARIES.resolve(library.path)).unzipTo(lwjglNativesTempDir)
                         .hash(library.sha1).size(library.size).withHttpClient(httpClient);
 
@@ -1507,7 +1508,7 @@ public class Instance extends MinecraftVersion {
                 FileUtils.copyFile(downloadLocation, finalLocation, true);
             }
         } else {
-            com.atlauncher.network.Download download = com.atlauncher.network.Download.build().setUrl(file.downloadUrl)
+            Download download = Download.build().setUrl(file.downloadUrl)
                     .downloadTo(downloadLocation).size(file.fileLength)
                     .withHttpClient(Network.createProgressClient(dialog));
 
@@ -1584,7 +1585,7 @@ public class Instance extends MinecraftVersion {
                 : (mod.projectType == ModrinthProjectType.SHADER
                         ? this.getRoot().resolve("shaderpacks").resolve(fileToDownload.filename)
                         : this.getRoot().resolve("resourcepacks").resolve(fileToDownload.filename));
-        com.atlauncher.network.Download download = com.atlauncher.network.Download.build().setUrl(fileToDownload.url)
+        Download download = Download.build().setUrl(fileToDownload.url)
                 .downloadTo(downloadLocation).copyTo(finalLocation)
                 .withHttpClient(Network.createProgressClient(dialog));
 
@@ -3240,24 +3241,13 @@ public class Instance extends MinecraftVersion {
         return Arrays.stream(folders).map(File::getName).collect(Collectors.toList());
     }
 
-    public boolean isQuickPlayMultiplayerSupported() {
+    public boolean isQuickPlaySupported(QuickPlayOption quickPlayOption) {
+        if (quickPlayOption.argumentRuleValue == null) {
+            return false;
+        }
         return arguments.game.stream().anyMatch(
             argumentRule -> argumentRule.value instanceof List &&
-                ((List<?>) argumentRule.value).contains("--quickPlayMultiplayer")
-        );
-    }
-
-    public boolean isQuickPlaySinglePlayerSupported() {
-        return arguments.game.stream().anyMatch(
-            argumentRule -> argumentRule.value instanceof List &&
-                ((List<?>) argumentRule.value).contains("--quickPlaySingleplayer")
-        );
-    }
-
-    public boolean isQuickPlayRealmsSupported() {
-        return arguments.game.stream().anyMatch(
-            argumentRule -> argumentRule.value instanceof List &&
-                ((List<?>) argumentRule.value).contains("--quickPlayRealms")
+                ((List<?>) argumentRule.value).contains(quickPlayOption.argumentRuleValue)
         );
     }
 
@@ -3305,10 +3295,10 @@ public class Instance extends MinecraftVersion {
                 continue;
             }
 
-            com.atlauncher.data.Type fileType = path.equals(ROOT.resolve("resourcepacks"))
-                    ? com.atlauncher.data.Type.resourcepack
-                    : (path.equals(ROOT.resolve("jarmods")) ? com.atlauncher.data.Type.jar
-                            : com.atlauncher.data.Type.mods);
+            Type fileType = path.equals(ROOT.resolve("resourcepacks"))
+                    ? Type.resourcepack
+                    : (path.equals(ROOT.resolve("jarmods")) ? Type.jar
+                            : Type.mods);
 
             try (Stream<Path> stream = Files.list(path)) {
                 files.addAll(stream
@@ -3329,10 +3319,10 @@ public class Instance extends MinecraftVersion {
             progressDialog.addThread(new Thread(() -> {
                 List<DisableableMod> mods = files.parallelStream()
                         .map(file -> {
-                            com.atlauncher.data.Type fileType = file.getParent().equals(ROOT.resolve("resourcepacks"))
-                                    ? com.atlauncher.data.Type.resourcepack
-                                    : (file.getParent().equals(ROOT.resolve("jarmods")) ? com.atlauncher.data.Type.jar
-                                            : com.atlauncher.data.Type.mods);
+                            Type fileType = file.getParent().equals(ROOT.resolve("resourcepacks"))
+                                    ? Type.resourcepack
+                                    : (file.getParent().equals(ROOT.resolve("jarmods")) ? Type.jar
+                                            : Type.mods);
 
                             return DisableableMod.generateMod(file.toFile(), fileType,
                                     !file.getParent().equals(ROOT.resolve("disabledmods")));
@@ -3471,7 +3461,7 @@ public class Instance extends MinecraftVersion {
         PerformanceManager.start("Instance::scanMissingMods - CheckForRemovedMods");
         // next remove any mods that the no longer exist in the filesystem
         List<DisableableMod> removedMods = launcher.mods.parallelStream().filter(mod -> {
-            if (!mod.wasSelected || mod.skipped || mod.type != com.atlauncher.data.Type.mods) {
+            if (!mod.wasSelected || mod.skipped || mod.type != Type.mods) {
                 return false;
             }
 
@@ -3494,7 +3484,7 @@ public class Instance extends MinecraftVersion {
         Set<File> seenModFiles = new HashSet<>();
         List<DisableableMod> duplicateMods = launcher.mods.stream()
                 .filter(mod -> {
-                    if (!mod.wasSelected || mod.skipped || mod.type != com.atlauncher.data.Type.mods) {
+                    if (!mod.wasSelected || mod.skipped || mod.type != Type.mods) {
                         return false;
                     }
 

--- a/src/main/java/com/atlauncher/data/InstanceLauncher.java
+++ b/src/main/java/com/atlauncher/data/InstanceLauncher.java
@@ -68,7 +68,7 @@ public class InstanceLauncher {
     public String javaRuntimeOverride = null;
     public String account;
     public Boolean enableDiscordIntegration = null;
-    public String joinInitialServerAddress = null;
+    public String initialJoinServerAddress = null;
     public Boolean useJavaProvidedByMinecraft = null;
     public Boolean disableLegacyLaunching = null;
     public Boolean enableCommands = null;

--- a/src/main/java/com/atlauncher/data/InstanceLauncher.java
+++ b/src/main/java/com/atlauncher/data/InstanceLauncher.java
@@ -68,6 +68,7 @@ public class InstanceLauncher {
     public String javaRuntimeOverride = null;
     public String account;
     public Boolean enableDiscordIntegration = null;
+    public String joinInitialServerAddress = null;
     public Boolean useJavaProvidedByMinecraft = null;
     public Boolean disableLegacyLaunching = null;
     public Boolean enableCommands = null;

--- a/src/main/java/com/atlauncher/data/InstanceLauncher.java
+++ b/src/main/java/com/atlauncher/data/InstanceLauncher.java
@@ -26,6 +26,7 @@ import com.atlauncher.data.curseforge.CurseForgeFile;
 import com.atlauncher.data.curseforge.CurseForgeProject;
 import com.atlauncher.data.curseforge.pack.CurseForgeManifest;
 import com.atlauncher.data.json.Java;
+import com.atlauncher.data.json.QuickPlay;
 import com.atlauncher.data.minecraft.loaders.LoaderVersion;
 import com.atlauncher.data.modpacksch.ModpacksChPackManifest;
 import com.atlauncher.data.modpacksch.ModpacksChPackVersionManifest;
@@ -68,7 +69,7 @@ public class InstanceLauncher {
     public String javaRuntimeOverride = null;
     public String account;
     public Boolean enableDiscordIntegration = null;
-    public String initialJoinServerAddress = null;
+    public QuickPlay quickPlay = QuickPlay.getDefault();
     public Boolean useJavaProvidedByMinecraft = null;
     public Boolean disableLegacyLaunching = null;
     public Boolean enableCommands = null;

--- a/src/main/java/com/atlauncher/data/QuickPlayOption.java
+++ b/src/main/java/com/atlauncher/data/QuickPlayOption.java
@@ -22,18 +22,16 @@ package com.atlauncher.data;
  * The values are from <a href="https://www.minecraft.net/en-us/article/minecraft-snapshot-23w14a">Minecraft QuickPlay</a>
  */
 public enum QuickPlayOption {
-    disabled("Disabled"),
-    singlePlayer("Single Player"),
-    multiPlayer("Multiplayer"),
-    realm("Minecraft Realm");
+    disabled("Disabled", null),
+    singlePlayer("Single Player", "--quickPlaySingleplayer"),
+    multiPlayer("Multiplayer", "--quickPlayMultiplayer"),
+    realm("Minecraft Realm", "--quickPlayRealms");
 
-    private final String label;
+    public final String label;
+    public final String argumentRuleValue;
 
-    QuickPlayOption(String label) {
+    QuickPlayOption(String label, String argumentRuleValue) {
         this.label = label;
-    }
-
-    public String getLabel() {
-        return label;
+        this.argumentRuleValue = argumentRuleValue;
     }
 }

--- a/src/main/java/com/atlauncher/data/QuickPlayOption.java
+++ b/src/main/java/com/atlauncher/data/QuickPlayOption.java
@@ -17,21 +17,44 @@
  */
 package com.atlauncher.data;
 
+import java.util.Arrays;
+
 /**
  * The types of the Quick Play options
  * The values are from <a href="https://www.minecraft.net/en-us/article/minecraft-snapshot-23w14a">Minecraft QuickPlay</a>
  */
 public enum QuickPlayOption {
-    disabled("Disabled", null),
-    singlePlayer("Single Player", "--quickPlaySingleplayer"),
-    multiPlayer("Multiplayer", "--quickPlayMultiplayer"),
-    realm("Minecraft Realm", "--quickPlayRealms");
+    disabled("Disabled", null, true),
+    singlePlayer("Single Player", "--quickPlaySingleplayer", false),
+    multiPlayer("Multiplayer", "--quickPlayMultiplayer", true),
+    realm("Minecraft Realm", "--quickPlayRealms", false);
 
     public final String label;
     public final String argumentRuleValue;
+    /**
+     * For the minecraft versions that doesn't have Quick plat feature, is this option available on older versions?
+     */
+    public final boolean compatibleOnOlderVersions;
 
-    QuickPlayOption(String label, String argumentRuleValue) {
+    /**
+     * Get only the compatible options for the current minecraft version regardless if it
+     * supports the quick play feature or not, for example joining a minecraft server is supported on older
+     * versions but with different way to use it (not using quick play feature)
+     */
+    public static QuickPlayOption[] compatibleValues(Instance instance) {
+        return Arrays.stream(values())
+            .filter(quickPlayOption -> {
+                if (instance.isQuickPlaySupported(quickPlayOption)) {
+                    return true;
+                }
+                return quickPlayOption.compatibleOnOlderVersions;
+            })
+            .toArray(QuickPlayOption[]::new);
+    }
+
+    QuickPlayOption(String label, String argumentRuleValue, boolean compatibleOnOlderVersions) {
         this.label = label;
         this.argumentRuleValue = argumentRuleValue;
+        this.compatibleOnOlderVersions = compatibleOnOlderVersions;
     }
 }

--- a/src/main/java/com/atlauncher/data/QuickPlayOption.java
+++ b/src/main/java/com/atlauncher/data/QuickPlayOption.java
@@ -1,0 +1,39 @@
+/*
+ * ATLauncher - https://github.com/ATLauncher/ATLauncher
+ * Copyright (C) 2013-2022 ATLauncher
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.atlauncher.data;
+
+/**
+ * The types of the Quick Play options
+ * The values are from <a href="https://www.minecraft.net/en-us/article/minecraft-snapshot-23w14a">Minecraft QuickPlay</a>
+ */
+public enum QuickPlayOption {
+    disabled("Disabled"),
+    singlePlayer("Single Player"),
+    multiPlayer("Multiplayer"),
+    realm("Minecraft Realm");
+
+    private final String label;
+
+    QuickPlayOption(String label) {
+        this.label = label;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+}

--- a/src/main/java/com/atlauncher/data/json/QuickPlay.java
+++ b/src/main/java/com/atlauncher/data/json/QuickPlay.java
@@ -36,27 +36,15 @@ public class QuickPlay {
         return new QuickPlay(null, null, null);
     }
 
-    private final String serverAddress;
-    private final String worldName;
+    public final String serverAddress;
+    public final String worldName;
     // TODO: Should we rename the realmId (--quickPlayRealms "1234")? if yes then make sure to rename it from all places
-    private final String realmId;
+    public final String realmId;
 
     public QuickPlay(String serverAddress, String worldName, String realmId) {
         this.serverAddress = serverAddress;
         this.worldName = worldName;
         this.realmId = realmId;
-    }
-
-    public String getServerAddress() {
-        return serverAddress;
-    }
-
-    public String getWorldName() {
-        return worldName;
-    }
-
-    public String getRealmId() {
-        return realmId;
     }
 
     /**

--- a/src/main/java/com/atlauncher/data/json/QuickPlay.java
+++ b/src/main/java/com/atlauncher/data/json/QuickPlay.java
@@ -38,7 +38,7 @@ public class QuickPlay {
 
     private final String serverAddress;
     private final String worldName;
-    // TODO: Should we rename the realmId?
+    // TODO: Should we rename the realmId (--quickPlayRealms "1234")? if yes then make sure to rename it from all places
     private final String realmId;
 
     public QuickPlay(String serverAddress, String worldName, String realmId) {

--- a/src/main/java/com/atlauncher/data/json/QuickPlay.java
+++ b/src/main/java/com/atlauncher/data/json/QuickPlay.java
@@ -50,7 +50,7 @@ public class QuickPlay {
     /**
      * @return The current/selected quick play option based on the data in this data class
      * */
-    public QuickPlayOption getQuickPlayOption() {
+    public QuickPlayOption getSelectedQuickPlayOption() {
         if (serverAddress != null) {
             return QuickPlayOption.multiPlayer;
         }

--- a/src/main/java/com/atlauncher/data/json/QuickPlay.java
+++ b/src/main/java/com/atlauncher/data/json/QuickPlay.java
@@ -1,0 +1,54 @@
+/*
+ * ATLauncher - https://github.com/ATLauncher/ATLauncher
+ * Copyright (C) 2013-2022 ATLauncher
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.atlauncher.data.json;
+
+import com.atlauncher.annot.Json;
+
+/**
+ * A data class that contains information about the quick play feature
+ * Either one of the fields should be not null or all of them should be null to disable the quick play feature.
+ * <p>
+ * This data is specific to ATLauncher and doesn't confirm or have the same underline data as Minecraft Launcher
+ */
+@Json
+public class QuickPlay {
+
+    /**
+     * The default value is null to all the properties
+     * */
+    public static QuickPlay getDefault() {
+        return new QuickPlay(null, null);
+    }
+
+    private final String serverAddress;
+    private final String worldName;
+    // TODO: Add support for realms quick play later
+
+    public QuickPlay(String serverAddress, String worldName) {
+        this.serverAddress = serverAddress;
+        this.worldName = worldName;
+    }
+
+    public String getServerAddress() {
+        return serverAddress;
+    }
+
+    public String getWorldName() {
+        return worldName;
+    }
+}

--- a/src/main/java/com/atlauncher/data/json/QuickPlay.java
+++ b/src/main/java/com/atlauncher/data/json/QuickPlay.java
@@ -18,6 +18,7 @@
 package com.atlauncher.data.json;
 
 import com.atlauncher.annot.Json;
+import com.atlauncher.data.QuickPlayOption;
 
 /**
  * A data class that contains information about the quick play feature
@@ -32,16 +33,18 @@ public class QuickPlay {
      * The default value is null to all the properties
      * */
     public static QuickPlay getDefault() {
-        return new QuickPlay(null, null);
+        return new QuickPlay(null, null, null);
     }
 
     private final String serverAddress;
     private final String worldName;
-    // TODO: Add support for realms quick play later
+    // TODO: Should we rename the realmId?
+    private final String realmId;
 
-    public QuickPlay(String serverAddress, String worldName) {
+    public QuickPlay(String serverAddress, String worldName, String realmId) {
         this.serverAddress = serverAddress;
         this.worldName = worldName;
+        this.realmId = realmId;
     }
 
     public String getServerAddress() {
@@ -50,5 +53,25 @@ public class QuickPlay {
 
     public String getWorldName() {
         return worldName;
+    }
+
+    public String getRealmId() {
+        return realmId;
+    }
+
+    /**
+     * @return The current/selected quick play option based on the data in this data class
+     * */
+    public QuickPlayOption getQuickPlayOption() {
+        if (serverAddress != null) {
+            return QuickPlayOption.multiPlayer;
+        }
+        if (worldName != null) {
+            return QuickPlayOption.singlePlayer;
+        }
+        if (realmId != null) {
+            return QuickPlayOption.realm;
+        }
+        return QuickPlayOption.disabled;
     }
 }

--- a/src/main/java/com/atlauncher/gui/dialogs/InstanceSettingsDialog.java
+++ b/src/main/java/com/atlauncher/gui/dialogs/InstanceSettingsDialog.java
@@ -106,7 +106,7 @@ public class InstanceSettingsDialog extends JDialog {
         JButton saveButton = new JButton(GetText.tr("Save"));
         saveButton.addActionListener(arg0 -> {
             if (javaInstanceSettingsTab.isValidJavaPath() && javaInstanceSettingsTab.isValidJavaParamaters()
-                && generalInstanceSettingsTab.isValidServerAddress()) {
+                && generalInstanceSettingsTab.isValidQuickPlayOptionValue()) {
                 saveSettings();
                 App.TOASTER.pop("Instance Settings Saved");
                 close();

--- a/src/main/java/com/atlauncher/gui/dialogs/InstanceSettingsDialog.java
+++ b/src/main/java/com/atlauncher/gui/dialogs/InstanceSettingsDialog.java
@@ -105,7 +105,8 @@ public class InstanceSettingsDialog extends JDialog {
 
         JButton saveButton = new JButton(GetText.tr("Save"));
         saveButton.addActionListener(arg0 -> {
-            if (javaInstanceSettingsTab.isValidJavaPath() && javaInstanceSettingsTab.isValidJavaParamaters()) {
+            if (javaInstanceSettingsTab.isValidJavaPath() && javaInstanceSettingsTab.isValidJavaParamaters()
+                && generalInstanceSettingsTab.isValidServerAddress()) {
                 saveSettings();
                 App.TOASTER.pop("Instance Settings Saved");
                 close();

--- a/src/main/java/com/atlauncher/gui/dialogs/instancesettings/GeneralInstanceSettingsTab.java
+++ b/src/main/java/com/atlauncher/gui/dialogs/instancesettings/GeneralInstanceSettingsTab.java
@@ -245,7 +245,7 @@ public class GeneralInstanceSettingsTab extends JPanel {
         quickPlayRealmIdLabel = new JLabelWithHover(
             GetText.tr("Minecraft Realm") + ":", HELP_ICON,
             GetText.tr(
-                "Type the name of the realm to join after launching the game (only work for newer " +
+                "Type the id of the realm to join after launching the game (only work for newer " +
                     "versions of minecraft)."
             )
         );

--- a/src/main/java/com/atlauncher/gui/dialogs/instancesettings/GeneralInstanceSettingsTab.java
+++ b/src/main/java/com/atlauncher/gui/dialogs/instancesettings/GeneralInstanceSettingsTab.java
@@ -177,11 +177,11 @@ public class GeneralInstanceSettingsTab extends JPanel {
         prepareAfterLabelComponentConstraints();
 
         quickPlayType = new JComboBox<>();
-        Arrays.stream(QuickPlayOption.values()).forEach(option ->
+        Arrays.stream(QuickPlayOption.compatibleValues(instance)).forEach(option ->
             quickPlayType.addItem(new ComboItem<>(option, GetText.tr(option.label)))
         );
         quickPlayType.setSelectedIndex(
-            Arrays.asList(QuickPlayOption.values()).indexOf(quickPlay.getSelectedQuickPlayOption())
+            Arrays.asList(QuickPlayOption.compatibleValues(instance)).indexOf(quickPlay.getSelectedQuickPlayOption())
         );
 
         // Code that is responsible for changing the input
@@ -219,8 +219,7 @@ public class GeneralInstanceSettingsTab extends JPanel {
         quickPlaySinglePlayerWorldLabel = new JLabelWithHover(
             GetText.tr("Single Player World") + ":", HELP_ICON,
             GetText.tr(
-                "Select the single player world to load after launching the game (only work for newer" +
-                    " versions of minecraft)."
+                "Select the single player world to load after launching the game."
             )
         );
         add(quickPlaySinglePlayerWorldLabel, gbc);
@@ -245,8 +244,7 @@ public class GeneralInstanceSettingsTab extends JPanel {
         quickPlayRealmIdLabel = new JLabelWithHover(
             GetText.tr("Minecraft Realm") + ":", HELP_ICON,
             GetText.tr(
-                "Type the id of the realm to join after launching the game (only work for newer " +
-                    "versions of minecraft)."
+                "Type the id of the realm to join after launching the game."
             )
         );
         add(quickPlayRealmIdLabel, gbc);

--- a/src/main/java/com/atlauncher/gui/dialogs/instancesettings/GeneralInstanceSettingsTab.java
+++ b/src/main/java/com/atlauncher/gui/dialogs/instancesettings/GeneralInstanceSettingsTab.java
@@ -24,6 +24,7 @@ import javax.swing.BorderFactory;
 import javax.swing.ImageIcon;
 import javax.swing.JComboBox;
 import javax.swing.JPanel;
+import javax.swing.JTextField;
 import javax.swing.border.Border;
 
 import org.mini2Dx.gettext.GetText;
@@ -43,6 +44,7 @@ public class GeneralInstanceSettingsTab extends JPanel {
 
     private JComboBox<ComboItem<String>> account;
     private JComboBox<ComboItem<Boolean>> enableDiscordIntegration;
+    private JTextField joinInitialServerAddress;
 
     final ImageIcon HELP_ICON = Utils.getIconImage(App.THEME.getIconPath("question"));
     final ImageIcon ERROR_ICON = Utils.getIconImage(App.THEME.getIconPath("error"));
@@ -123,12 +125,38 @@ public class GeneralInstanceSettingsTab extends JPanel {
         }
 
         add(enableDiscordIntegration, gbc);
+
+        // Join server on launch
+
+        gbc.gridx = 0;
+        gbc.gridy++;
+        gbc.insets = UIConstants.LABEL_INSETS;
+        gbc.anchor = GridBagConstraints.BASELINE_TRAILING;
+
+        JLabelWithHover joinInitialServerAddressLabel = new JLabelWithHover(
+            GetText.tr("Join Server On Launch") + ":", HELP_ICON,
+            GetText.tr(
+                "Enter the server address if you want to join a Minecraft server when you launch the game, " +
+                    "leave it empty if you don't want to join a server after launching the game."
+            )
+        );
+
+        add(joinInitialServerAddressLabel, gbc);
+
+        gbc.gridx++;
+        gbc.insets = UIConstants.FIELD_INSETS;
+        gbc.anchor = GridBagConstraints.BASELINE_LEADING;
+        joinInitialServerAddress = new JTextField(13);
+        joinInitialServerAddress.setText(instance.launcher.joinInitialServerAddress);
+
+        add(joinInitialServerAddress, gbc);
     }
 
     public void saveSettings() {
         this.instance.launcher.account = ((ComboItem<String>) account.getSelectedItem()).getValue();
         this.instance.launcher.enableDiscordIntegration = ((ComboItem<Boolean>) enableDiscordIntegration
                 .getSelectedItem()).getValue();
+        this.instance.launcher.joinInitialServerAddress = joinInitialServerAddress.getText();
     }
 
 }

--- a/src/main/java/com/atlauncher/gui/dialogs/instancesettings/GeneralInstanceSettingsTab.java
+++ b/src/main/java/com/atlauncher/gui/dialogs/instancesettings/GeneralInstanceSettingsTab.java
@@ -33,6 +33,7 @@ import com.atlauncher.App;
 import com.atlauncher.builders.HTMLBuilder;
 import com.atlauncher.constants.UIConstants;
 import com.atlauncher.data.Instance;
+import com.atlauncher.data.json.QuickPlay;
 import com.atlauncher.gui.components.JLabelWithHover;
 import com.atlauncher.managers.AccountManager;
 import com.atlauncher.managers.DialogManager;
@@ -129,7 +130,9 @@ public class GeneralInstanceSettingsTab extends JPanel {
 
         add(enableDiscordIntegration, gbc);
 
-        // Join server on launch
+        // Quick play section
+
+        // TODO: Add support for quick play for single player and realms later
 
         gbc.gridx = 0;
         gbc.gridy++;
@@ -154,7 +157,7 @@ public class GeneralInstanceSettingsTab extends JPanel {
         initialJoinServerAddress.putClientProperty("JTextField.clearCallback", (Runnable) () -> {
             initialJoinServerAddress.setText("");
         });
-        initialJoinServerAddress.setText(instance.launcher.initialJoinServerAddress);
+        initialJoinServerAddress.setText(instance.launcher.quickPlay.getServerAddress());
 
         add(initialJoinServerAddress, gbc);
     }
@@ -177,7 +180,10 @@ public class GeneralInstanceSettingsTab extends JPanel {
         this.instance.launcher.account = ((ComboItem<String>) account.getSelectedItem()).getValue();
         this.instance.launcher.enableDiscordIntegration = ((ComboItem<Boolean>) enableDiscordIntegration
                 .getSelectedItem()).getValue();
-        this.instance.launcher.initialJoinServerAddress = initialJoinServerAddress.getText();
+        this.instance.launcher.quickPlay = new QuickPlay(
+            initialJoinServerAddress.getText(),
+            null
+        );
     }
 
 }

--- a/src/main/java/com/atlauncher/gui/dialogs/instancesettings/GeneralInstanceSettingsTab.java
+++ b/src/main/java/com/atlauncher/gui/dialogs/instancesettings/GeneralInstanceSettingsTab.java
@@ -147,6 +147,10 @@ public class GeneralInstanceSettingsTab extends JPanel {
         gbc.insets = UIConstants.FIELD_INSETS;
         gbc.anchor = GridBagConstraints.BASELINE_LEADING;
         initialJoinServerAddress = new JTextField(13);
+        initialJoinServerAddress.putClientProperty("JTextField.showClearButton", true);
+        initialJoinServerAddress.putClientProperty("JTextField.clearCallback", (Runnable) () -> {
+            initialJoinServerAddress.setText("");
+        });
         initialJoinServerAddress.setText(instance.launcher.initialJoinServerAddress);
 
         add(initialJoinServerAddress, gbc);

--- a/src/main/java/com/atlauncher/gui/dialogs/instancesettings/GeneralInstanceSettingsTab.java
+++ b/src/main/java/com/atlauncher/gui/dialogs/instancesettings/GeneralInstanceSettingsTab.java
@@ -30,13 +30,16 @@ import javax.swing.border.Border;
 import org.mini2Dx.gettext.GetText;
 
 import com.atlauncher.App;
+import com.atlauncher.builders.HTMLBuilder;
 import com.atlauncher.constants.UIConstants;
 import com.atlauncher.data.Instance;
 import com.atlauncher.gui.components.JLabelWithHover;
 import com.atlauncher.managers.AccountManager;
+import com.atlauncher.managers.DialogManager;
 import com.atlauncher.utils.ComboItem;
 import com.atlauncher.utils.OS;
 import com.atlauncher.utils.Utils;
+import com.atlauncher.utils.ValidationUtils;
 
 @SuppressWarnings("serial")
 public class GeneralInstanceSettingsTab extends JPanel {
@@ -137,7 +140,7 @@ public class GeneralInstanceSettingsTab extends JPanel {
             GetText.tr("Join Server On Launch") + ":", HELP_ICON,
             GetText.tr(
                 "Enter the server address if you want to join a Minecraft server when you launch the game, " +
-                    "leave it empty if you don't want to join a server after launching the game."
+                    "leave it empty if you don't want to."
             )
         );
 
@@ -154,6 +157,20 @@ public class GeneralInstanceSettingsTab extends JPanel {
         initialJoinServerAddress.setText(instance.launcher.initialJoinServerAddress);
 
         add(initialJoinServerAddress, gbc);
+    }
+
+    // TODO: Rename this method when we decide the name of [initialJoinServerAddress]
+    public boolean isValidServerAddress() {
+        if (!initialJoinServerAddress.getText().isEmpty() &&
+            !ValidationUtils.isValidMinecraftServerAddress(initialJoinServerAddress.getText())) {
+            DialogManager.okDialog().setTitle(GetText.tr("Error"))
+                .setContent(new HTMLBuilder().center()
+                    .text(GetText.tr("The entered server address is invalid."))
+                    .build())
+                .setType(DialogManager.ERROR).show();
+            return false;
+        }
+        return true;
     }
 
     public void saveSettings() {

--- a/src/main/java/com/atlauncher/gui/dialogs/instancesettings/GeneralInstanceSettingsTab.java
+++ b/src/main/java/com/atlauncher/gui/dialogs/instancesettings/GeneralInstanceSettingsTab.java
@@ -209,7 +209,7 @@ public class GeneralInstanceSettingsTab extends JPanel {
         quickPlayServerAddress = new JTextField(13);
         quickPlayServerAddress.putClientProperty("JTextField.showClearButton", true);
         quickPlayServerAddress.putClientProperty("JTextField.clearCallback", (Runnable) () -> quickPlayServerAddress.setText(""));
-        quickPlayServerAddress.setText(quickPlay.getServerAddress());
+        quickPlayServerAddress.setText(quickPlay.serverAddress);
 
         add(quickPlayServerAddress, gbc);
 
@@ -233,7 +233,7 @@ public class GeneralInstanceSettingsTab extends JPanel {
         ));
 
         if (!worldNames.isEmpty()) {
-            final int selectedWorldFolderNameIndex = worldNames.indexOf(quickPlay.getWorldName());
+            final int selectedWorldFolderNameIndex = worldNames.indexOf(quickPlay.worldName);
             quickPlaySinglePlayerWorld.setSelectedIndex(
                 selectedWorldFolderNameIndex != -1 ? selectedWorldFolderNameIndex : 0
             );
@@ -256,7 +256,7 @@ public class GeneralInstanceSettingsTab extends JPanel {
         quickPlayRealmId = new JTextField(13);
         quickPlayRealmId.putClientProperty("JTextField.showClearButton", true);
         quickPlayRealmId.putClientProperty("JTextField.clearCallback", (Runnable) () -> quickPlayRealmId.setText(""));
-        quickPlayRealmId.setText(quickPlay.getRealmId());
+        quickPlayRealmId.setText(quickPlay.realmId);
 
         add(quickPlayRealmId, gbc);
 

--- a/src/main/java/com/atlauncher/gui/dialogs/instancesettings/GeneralInstanceSettingsTab.java
+++ b/src/main/java/com/atlauncher/gui/dialogs/instancesettings/GeneralInstanceSettingsTab.java
@@ -19,6 +19,8 @@ package com.atlauncher.gui.dialogs.instancesettings;
 
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
+import java.util.Arrays;
+import java.util.List;
 
 import javax.swing.BorderFactory;
 import javax.swing.ImageIcon;
@@ -33,6 +35,7 @@ import com.atlauncher.App;
 import com.atlauncher.builders.HTMLBuilder;
 import com.atlauncher.constants.UIConstants;
 import com.atlauncher.data.Instance;
+import com.atlauncher.data.QuickPlayOption;
 import com.atlauncher.data.json.QuickPlay;
 import com.atlauncher.gui.components.JLabelWithHover;
 import com.atlauncher.managers.AccountManager;
@@ -48,7 +51,19 @@ public class GeneralInstanceSettingsTab extends JPanel {
 
     private JComboBox<ComboItem<String>> account;
     private JComboBox<ComboItem<Boolean>> enableDiscordIntegration;
-    private JTextField initialJoinServerAddress;
+
+    // TODO: We might want to add a Swing component that hold both the label and the input (text field or dropdown etc...)
+
+    private JComboBox<ComboItem<QuickPlayOption>> quickPlayType;
+
+    private JLabelWithHover quickPlayServerAddressLabel;
+    private JTextField quickPlayServerAddress;
+
+    private JLabelWithHover quickPlaySinglePlayerWorldLabel;
+    private JComboBox<ComboItem<String>> quickPlaySinglePlayerWorld;
+
+    private JLabelWithHover quickPlayRealmIdLabel;
+    private JTextField quickPlayRealmId;
 
     final ImageIcon HELP_ICON = Utils.getIconImage(App.THEME.getIconPath("question"));
     final ImageIcon ERROR_ICON = Utils.getIconImage(App.THEME.getIconPath("error"));
@@ -64,24 +79,40 @@ public class GeneralInstanceSettingsTab extends JPanel {
         setupComponents();
     }
 
+    /**
+     * Prepares [GridBagConstraints] for adding a new label component.
+     * it should be called before adding the label to the panel
+     * */
+    void prepareLabelConstraints() {
+        gbc.gridx = 0;
+        gbc.gridy++;
+        gbc.insets = UIConstants.LABEL_INSETS;
+        gbc.anchor = GridBagConstraints.BASELINE_TRAILING;
+    }
+
+    /**
+     * Prepares [GridBagConstraints] for adding a component after a label.
+     * it should be called before adding the component to the panel
+     * */
+    void prepareAfterLabelComponentConstraints() {
+        gbc.gridx++;
+        gbc.insets = UIConstants.FIELD_INSETS;
+        gbc.anchor = GridBagConstraints.BASELINE_LEADING;
+    }
+
     private void setupComponents() {
         setLayout(new GridBagLayout());
 
         // Account
 
-        gbc.gridx = 0;
-        gbc.gridy++;
-        gbc.insets = UIConstants.LABEL_INSETS;
-        gbc.anchor = GridBagConstraints.BASELINE_TRAILING;
+        prepareLabelConstraints();
 
         JLabelWithHover accountLabel = new JLabelWithHover(GetText.tr("Account Override") + ":", HELP_ICON, GetText.tr(
                 "Which account to use when launching this instance. Use Launcher Default will use whichever account is selected in the launcher."));
 
         add(accountLabel, gbc);
 
-        gbc.gridx++;
-        gbc.insets = UIConstants.FIELD_INSETS;
-        gbc.anchor = GridBagConstraints.BASELINE_LEADING;
+        prepareAfterLabelComponentConstraints();
         account = new JComboBox<>();
         account.addItem(new ComboItem<>(null, GetText.tr("Use Launcher Default")));
         AccountManager.getAccounts().stream()
@@ -101,18 +132,13 @@ public class GeneralInstanceSettingsTab extends JPanel {
 
         // Enable Discord Integration
 
-        gbc.gridx = 0;
-        gbc.gridy++;
-        gbc.insets = UIConstants.LABEL_INSETS;
-        gbc.anchor = GridBagConstraints.BASELINE_TRAILING;
+        prepareLabelConstraints();
         JLabelWithHover enableDiscordIntegrationLabel = new JLabelWithHover(
                 GetText.tr("Enable Discord Integration") + "?", HELP_ICON,
                 GetText.tr("This will enable showing which pack you're playing in Discord."));
         add(enableDiscordIntegrationLabel, gbc);
 
-        gbc.gridx++;
-        gbc.insets = UIConstants.FIELD_INSETS;
-        gbc.anchor = GridBagConstraints.BASELINE_LEADING;
+        prepareAfterLabelComponentConstraints();
         enableDiscordIntegration = new JComboBox<>();
         enableDiscordIntegration.addItem(new ComboItem<>(null, GetText.tr("Use Launcher Default")));
         enableDiscordIntegration.addItem(new ComboItem<>(true, GetText.tr("Yes")));
@@ -132,46 +158,195 @@ public class GeneralInstanceSettingsTab extends JPanel {
 
         // Quick play section
 
-        // TODO: Add support for quick play for single player and realms later
+        QuickPlay quickPlay = instance.launcher.quickPlay;
 
-        gbc.gridx = 0;
-        gbc.gridy++;
-        gbc.insets = UIConstants.LABEL_INSETS;
-        gbc.anchor = GridBagConstraints.BASELINE_TRAILING;
+        // Quick Play options
 
-        JLabelWithHover initialJoinServerAddressLabel = new JLabelWithHover(
-            GetText.tr("Join Server On Launch") + ":", HELP_ICON,
+        prepareLabelConstraints();
+
+        // Quick Play Feature components
+        JLabelWithHover quickPlayTypeLabel = new JLabelWithHover(
+            GetText.tr("Quick Play Type") + ":", HELP_ICON,
             GetText.tr(
-                "Enter the server address if you want to join a Minecraft server when you launch the game, " +
-                    "leave it empty if you don't want to."
+                "Select the type of the Quick Play feature, default to disabled."
             )
         );
 
-        add(initialJoinServerAddressLabel, gbc);
+        add(quickPlayTypeLabel, gbc);
 
-        gbc.gridx++;
-        gbc.insets = UIConstants.FIELD_INSETS;
-        gbc.anchor = GridBagConstraints.BASELINE_LEADING;
-        initialJoinServerAddress = new JTextField(13);
-        initialJoinServerAddress.putClientProperty("JTextField.showClearButton", true);
-        initialJoinServerAddress.putClientProperty("JTextField.clearCallback", (Runnable) () -> {
-            initialJoinServerAddress.setText("");
-        });
-        initialJoinServerAddress.setText(instance.launcher.quickPlay.getServerAddress());
+        prepareAfterLabelComponentConstraints();
 
-        add(initialJoinServerAddress, gbc);
+        quickPlayType = new JComboBox<>();
+        Arrays.stream(QuickPlayOption.values()).forEach(option ->
+            quickPlayType.addItem(new ComboItem<>(option, GetText.tr(option.getLabel())))
+        );
+        quickPlayType.setSelectedIndex(
+            Arrays.asList(QuickPlayOption.values()).indexOf(quickPlay.getQuickPlayOption())
+        );
+
+        // Code that is responsible for changing the input
+        quickPlayType.addActionListener(e -> showInputForTheSelectedQuickPlayOption());
+
+        add(quickPlayType, gbc);
+
+        // Quick play server address
+
+        // TODO: Allow to select the list of the servers in the game using dropdown as a value for this text input
+
+        prepareLabelConstraints();
+
+        quickPlayServerAddressLabel = new JLabelWithHover(
+            GetText.tr("Server address") + ":", HELP_ICON,
+            GetText.tr(
+                "The server address that is used to connect to Minecraft server in multiplayer after" +
+                    " launching the game."
+            )
+        );
+
+        add(quickPlayServerAddressLabel, gbc);
+
+        prepareAfterLabelComponentConstraints();
+        quickPlayServerAddress = new JTextField(13);
+        quickPlayServerAddress.putClientProperty("JTextField.showClearButton", true);
+        quickPlayServerAddress.putClientProperty("JTextField.clearCallback", (Runnable) () -> quickPlayServerAddress.setText(""));
+        quickPlayServerAddress.setText(quickPlay.getServerAddress());
+
+        add(quickPlayServerAddress, gbc);
+
+        // Quick play select single player world dropdown
+
+        prepareLabelConstraints();
+        quickPlaySinglePlayerWorldLabel = new JLabelWithHover(
+            GetText.tr("Single Player World") + ":", HELP_ICON,
+            GetText.tr(
+                "Select the single player world to load after launching the game (only work for newer" +
+                    " versions of minecraft)."
+            )
+        );
+        add(quickPlaySinglePlayerWorldLabel, gbc);
+
+        prepareAfterLabelComponentConstraints();
+        quickPlaySinglePlayerWorld = new JComboBox<>();
+        List<String> worldNames = instance.getSinglePlayerWorldNamesFromFilesystem();
+        worldNames.forEach(saveName ->
+            quickPlaySinglePlayerWorld.addItem(new ComboItem<>(saveName, saveName)
+        ));
+
+        if (!worldNames.isEmpty()) {
+            final int selectedWorldFolderNameIndex = worldNames.indexOf(quickPlay.getWorldName());
+            quickPlaySinglePlayerWorld.setSelectedIndex(
+                selectedWorldFolderNameIndex != -1 ? selectedWorldFolderNameIndex : 0
+            );
+        }
+
+        add(quickPlaySinglePlayerWorld, gbc);
+
+        prepareLabelConstraints();
+        quickPlayRealmIdLabel = new JLabelWithHover(
+            GetText.tr("Minecraft Realm") + ":", HELP_ICON,
+            GetText.tr(
+                "Type the name of the realm to join after launching the game (only work for newer " +
+                    "versions of minecraft)."
+            )
+        );
+        add(quickPlayRealmIdLabel, gbc);
+
+        // TODO: We might want to make this as dropdown to all the realms
+        prepareAfterLabelComponentConstraints();
+        quickPlayRealmId = new JTextField(13);
+        quickPlayRealmId.putClientProperty("JTextField.showClearButton", true);
+        quickPlayRealmId.putClientProperty("JTextField.clearCallback", (Runnable) () -> quickPlayRealmId.setText(""));
+        quickPlayRealmId.setText(quickPlay.getRealmId());
+
+        add(quickPlayRealmId, gbc);
+
+        // Show only the input for the selected quick play type
+        showInputForTheSelectedQuickPlayOption();
     }
 
-    // TODO: Rename this method when we decide the name of [initialJoinServerAddress]
-    public boolean isValidServerAddress() {
-        if (!initialJoinServerAddress.getText().isEmpty() &&
-            !ValidationUtils.isValidMinecraftServerAddress(initialJoinServerAddress.getText())) {
-            DialogManager.okDialog().setTitle(GetText.tr("Error"))
-                .setContent(new HTMLBuilder().center()
-                    .text(GetText.tr("The entered server address is invalid."))
-                    .build())
-                .setType(DialogManager.ERROR).show();
-            return false;
+    /**
+     * A helper method to set the correct visibility for all the quick play inputs
+     * */
+    public void showInputForTheSelectedQuickPlayOption() {
+        QuickPlayOption quickPlayOption = ((ComboItem<QuickPlayOption>) quickPlayType.getSelectedItem()).getValue();
+        switch (quickPlayOption) {
+            case disabled:
+                // Hide all
+                setQuickPlayInputsVisibility(false, false, false);
+                break;
+            case multiPlayer:
+                // Only show the server address input field
+                setQuickPlayInputsVisibility(true, false, false);
+                break;
+            case singlePlayer:
+                // Only show the select world dropdown
+                setQuickPlayInputsVisibility(false, true, false);
+                break;
+            case realm:
+                setQuickPlayInputsVisibility(false, false, true);
+                break;
+        }
+    }
+
+    /**
+     * A helper method to set the visibility for different quick play inputs (multiplayer, single player, realms)
+     * */
+    public void setQuickPlayInputsVisibility(
+        boolean serverAddress,
+        boolean singlePlayerWorld,
+        boolean realmId
+    ) {
+        quickPlayServerAddressLabel.setVisible(serverAddress);
+        quickPlayServerAddress.setVisible(serverAddress);
+        quickPlaySinglePlayerWorldLabel.setVisible(singlePlayerWorld);
+        quickPlaySinglePlayerWorld.setVisible(singlePlayerWorld);
+        quickPlayRealmIdLabel.setVisible(realmId);
+        quickPlayRealmId.setVisible(realmId);
+    }
+
+    public boolean isValidQuickPlayOptionValue() {
+        QuickPlayOption quickPlayOption = ((ComboItem<QuickPlayOption>) quickPlayType.getSelectedItem()).getValue();
+        switch(quickPlayOption) {
+            case disabled:
+                return true;
+            case singlePlayer:
+                if (quickPlaySinglePlayerWorld.getSelectedItem() == null) {
+                    DialogManager.okDialog().setTitle(GetText.tr("Invalid Input"))
+                        .setContent(new HTMLBuilder().center()
+                            .text(GetText.tr("You don't have any single player worlds yet on this instance."))
+                            .build())
+                        .setType(DialogManager.ERROR).show();
+                    return false;
+                }
+                return true;
+            case multiPlayer:
+                if (quickPlayServerAddress.getText().isEmpty()) {
+                    DialogManager.okDialog().setTitle(GetText.tr("Invalid Input"))
+                        .setContent(new HTMLBuilder().center()
+                            .text(GetText.tr("The server address is empty."))
+                            .build())
+                        .setType(DialogManager.ERROR).show();
+                    return false;
+                }
+                if (!ValidationUtils.isValidMinecraftServerAddress(quickPlayServerAddress.getText())) {
+                    DialogManager.okDialog().setTitle(GetText.tr("Invalid Input"))
+                        .setContent(new HTMLBuilder().center()
+                            .text(GetText.tr("The entered server address is invalid."))
+                            .build())
+                        .setType(DialogManager.ERROR).show();
+                    return false;
+                }
+                return true;
+            case realm:
+                if (quickPlayRealmId.getText().isEmpty()) {
+                    DialogManager.okDialog().setTitle(GetText.tr("Invalid Input"))
+                        .setContent(new HTMLBuilder().center()
+                            .text(GetText.tr("The realm id is empty."))
+                            .build())
+                        .setType(DialogManager.ERROR).show();
+                    return false;
+                }
+                return true;
         }
         return true;
     }
@@ -179,10 +354,13 @@ public class GeneralInstanceSettingsTab extends JPanel {
     public void saveSettings() {
         this.instance.launcher.account = ((ComboItem<String>) account.getSelectedItem()).getValue();
         this.instance.launcher.enableDiscordIntegration = ((ComboItem<Boolean>) enableDiscordIntegration
-                .getSelectedItem()).getValue();
+            .getSelectedItem()).getValue();
+        QuickPlayOption quickPlayOption = ((ComboItem<QuickPlayOption>) quickPlayType.getSelectedItem()).getValue();
         this.instance.launcher.quickPlay = new QuickPlay(
-            initialJoinServerAddress.getText(),
-            null
+            quickPlayOption == QuickPlayOption.multiPlayer ? quickPlayServerAddress.getText() : null,
+            quickPlayOption == QuickPlayOption.singlePlayer ?
+                ((ComboItem<String>) quickPlaySinglePlayerWorld.getSelectedItem()).getValue() : null,
+            quickPlayOption == QuickPlayOption.realm ? quickPlayRealmId.getText() : null
         );
     }
 

--- a/src/main/java/com/atlauncher/gui/dialogs/instancesettings/GeneralInstanceSettingsTab.java
+++ b/src/main/java/com/atlauncher/gui/dialogs/instancesettings/GeneralInstanceSettingsTab.java
@@ -44,7 +44,7 @@ public class GeneralInstanceSettingsTab extends JPanel {
 
     private JComboBox<ComboItem<String>> account;
     private JComboBox<ComboItem<Boolean>> enableDiscordIntegration;
-    private JTextField joinInitialServerAddress;
+    private JTextField initialJoinServerAddress;
 
     final ImageIcon HELP_ICON = Utils.getIconImage(App.THEME.getIconPath("question"));
     final ImageIcon ERROR_ICON = Utils.getIconImage(App.THEME.getIconPath("error"));
@@ -133,7 +133,7 @@ public class GeneralInstanceSettingsTab extends JPanel {
         gbc.insets = UIConstants.LABEL_INSETS;
         gbc.anchor = GridBagConstraints.BASELINE_TRAILING;
 
-        JLabelWithHover joinInitialServerAddressLabel = new JLabelWithHover(
+        JLabelWithHover initialJoinServerAddressLabel = new JLabelWithHover(
             GetText.tr("Join Server On Launch") + ":", HELP_ICON,
             GetText.tr(
                 "Enter the server address if you want to join a Minecraft server when you launch the game, " +
@@ -141,22 +141,22 @@ public class GeneralInstanceSettingsTab extends JPanel {
             )
         );
 
-        add(joinInitialServerAddressLabel, gbc);
+        add(initialJoinServerAddressLabel, gbc);
 
         gbc.gridx++;
         gbc.insets = UIConstants.FIELD_INSETS;
         gbc.anchor = GridBagConstraints.BASELINE_LEADING;
-        joinInitialServerAddress = new JTextField(13);
-        joinInitialServerAddress.setText(instance.launcher.joinInitialServerAddress);
+        initialJoinServerAddress = new JTextField(13);
+        initialJoinServerAddress.setText(instance.launcher.initialJoinServerAddress);
 
-        add(joinInitialServerAddress, gbc);
+        add(initialJoinServerAddress, gbc);
     }
 
     public void saveSettings() {
         this.instance.launcher.account = ((ComboItem<String>) account.getSelectedItem()).getValue();
         this.instance.launcher.enableDiscordIntegration = ((ComboItem<Boolean>) enableDiscordIntegration
                 .getSelectedItem()).getValue();
-        this.instance.launcher.joinInitialServerAddress = joinInitialServerAddress.getText();
+        this.instance.launcher.initialJoinServerAddress = initialJoinServerAddress.getText();
     }
 
 }

--- a/src/main/java/com/atlauncher/gui/dialogs/instancesettings/GeneralInstanceSettingsTab.java
+++ b/src/main/java/com/atlauncher/gui/dialogs/instancesettings/GeneralInstanceSettingsTab.java
@@ -178,10 +178,10 @@ public class GeneralInstanceSettingsTab extends JPanel {
 
         quickPlayType = new JComboBox<>();
         Arrays.stream(QuickPlayOption.values()).forEach(option ->
-            quickPlayType.addItem(new ComboItem<>(option, GetText.tr(option.getLabel())))
+            quickPlayType.addItem(new ComboItem<>(option, GetText.tr(option.label)))
         );
         quickPlayType.setSelectedIndex(
-            Arrays.asList(QuickPlayOption.values()).indexOf(quickPlay.getQuickPlayOption())
+            Arrays.asList(QuickPlayOption.values()).indexOf(quickPlay.getSelectedQuickPlayOption())
         );
 
         // Code that is responsible for changing the input

--- a/src/main/java/com/atlauncher/mclauncher/MCLauncher.java
+++ b/src/main/java/com/atlauncher/mclauncher/MCLauncher.java
@@ -409,6 +409,28 @@ public class MCLauncher {
             }
         }
 
+        // Joining a server on launch
+        if (instance.launcher.joinInitialServerAddress != null && !instance.launcher.joinInitialServerAddress.isEmpty()) {
+            String enteredServerAddress = instance.launcher.joinInitialServerAddress;
+            boolean hasQuickMultiplayer = instance.arguments.game.stream().anyMatch(
+                argumentRule -> argumentRule.value instanceof List &&
+                    ((List<?>) argumentRule.value).contains("--quickPlayMultiplayer")
+            );
+            if (hasQuickMultiplayer) {
+                // Minecraft 23w14a and newer versions
+                arguments.add("--quickPlayMultiplayer");
+                arguments.add(enteredServerAddress);
+            } else {
+                // Minecraft version 23w13a and older versions
+                String[] parts = enteredServerAddress.contains(":") ? enteredServerAddress.split(":")
+                    : new String[]{enteredServerAddress};
+                String address = parts[0];
+                String port = parts.length > 1 ? parts[1] : String.valueOf(Constants.MINECRAFT_DEFAULT_SERVER_PORT);
+                arguments.addAll(Arrays.asList("--server", address));
+                arguments.addAll(Arrays.asList("--port", port));
+            }
+        }
+
         return arguments;
     }
 

--- a/src/main/java/com/atlauncher/mclauncher/MCLauncher.java
+++ b/src/main/java/com/atlauncher/mclauncher/MCLauncher.java
@@ -421,7 +421,7 @@ public class MCLauncher {
                 arguments.add("--quickPlayMultiplayer");
                 arguments.add(enteredServerAddress);
             } else {
-                // Minecraft version 23w13a and older versions
+                // Minecraft 23w13a and older versions
                 String[] parts = enteredServerAddress.contains(":") ? enteredServerAddress.split(":")
                     : new String[]{enteredServerAddress};
                 String address = parts[0];

--- a/src/main/java/com/atlauncher/mclauncher/MCLauncher.java
+++ b/src/main/java/com/atlauncher/mclauncher/MCLauncher.java
@@ -37,6 +37,7 @@ import com.atlauncher.data.Instance;
 import com.atlauncher.data.LoginResponse;
 import com.atlauncher.data.MicrosoftAccount;
 import com.atlauncher.data.MojangAccount;
+import com.atlauncher.data.QuickPlayOption;
 import com.atlauncher.data.json.QuickPlay;
 import com.atlauncher.data.minecraft.Library;
 import com.atlauncher.data.minecraft.LoggingClient;
@@ -416,9 +417,9 @@ public class MCLauncher {
         // Quick Play Multiplayer
         if (quickPlay.serverAddress != null && !quickPlay.serverAddress.isEmpty()) {
             String enteredServerAddress = quickPlay.serverAddress;
-            if (instance.isQuickPlayMultiplayerSupported()) {
+            if (instance.isQuickPlaySupported(QuickPlayOption.multiPlayer)) {
                 // Minecraft 23w14a and newer versions
-                arguments.addAll(Arrays.asList("--quickPlayMultiplayer", enteredServerAddress));
+                arguments.addAll(Arrays.asList(quickPlay.getSelectedQuickPlayOption().argumentRuleValue, enteredServerAddress));
                 arguments.add(enteredServerAddress);
             } else {
                 // Minecraft 23w13a and older versions
@@ -434,18 +435,18 @@ public class MCLauncher {
         // Quick Play Single Player
         if (quickPlay.worldName != null && !quickPlay.worldName.isEmpty()) {
             String selectedWorldSaveName = quickPlay.worldName;
-            if (instance.isQuickPlaySinglePlayerSupported()) {
+            if (instance.isQuickPlaySupported(QuickPlayOption.singlePlayer)) {
                 // Only work for Minecraft 23w14a and newer versions
-                arguments.addAll(Arrays.asList("--quickPlaySingleplayer", selectedWorldSaveName));
+                arguments.addAll(Arrays.asList(quickPlay.getSelectedQuickPlayOption().argumentRuleValue, selectedWorldSaveName));
             }
         }
 
         // Quick Play Realm
         if (quickPlay.realmId != null && !quickPlay.realmId.isEmpty()) {
             String realmId = quickPlay.realmId;
-            if (instance.isQuickPlayRealmsSupported()) {
+            if (instance.isQuickPlaySupported(QuickPlayOption.realm)) {
                 // Only work for Minecraft 23w14a and newer versions
-                arguments.addAll(Arrays.asList("--quickPlayRealms", realmId));
+                arguments.addAll(Arrays.asList(quickPlay.getSelectedQuickPlayOption().argumentRuleValue, realmId));
             }
         }
 

--- a/src/main/java/com/atlauncher/mclauncher/MCLauncher.java
+++ b/src/main/java/com/atlauncher/mclauncher/MCLauncher.java
@@ -410,8 +410,8 @@ public class MCLauncher {
         }
 
         // Joining a server on launch
-        if (instance.launcher.joinInitialServerAddress != null && !instance.launcher.joinInitialServerAddress.isEmpty()) {
-            String enteredServerAddress = instance.launcher.joinInitialServerAddress;
+        if (instance.launcher.initialJoinServerAddress != null && !instance.launcher.initialJoinServerAddress.isEmpty()) {
+            String enteredServerAddress = instance.launcher.initialJoinServerAddress;
             boolean hasQuickMultiplayer = instance.arguments.game.stream().anyMatch(
                 argumentRule -> argumentRule.value instanceof List &&
                     ((List<?>) argumentRule.value).contains("--quickPlayMultiplayer")

--- a/src/main/java/com/atlauncher/mclauncher/MCLauncher.java
+++ b/src/main/java/com/atlauncher/mclauncher/MCLauncher.java
@@ -416,11 +416,7 @@ public class MCLauncher {
         // Quick Play Multiplayer
         if (quickPlay.serverAddress != null && !quickPlay.serverAddress.isEmpty()) {
             String enteredServerAddress = quickPlay.serverAddress;
-            boolean hasQuickPlayMultiplayer = instance.arguments.game.stream().anyMatch(
-                argumentRule -> argumentRule.value instanceof List &&
-                    ((List<?>) argumentRule.value).contains("--quickPlayMultiplayer")
-            );
-            if (hasQuickPlayMultiplayer) {
+            if (instance.isQuickPlayMultiplayerSupported()) {
                 // Minecraft 23w14a and newer versions
                 arguments.addAll(Arrays.asList("--quickPlayMultiplayer", enteredServerAddress));
                 arguments.add(enteredServerAddress);
@@ -438,11 +434,7 @@ public class MCLauncher {
         // Quick Play Single Player
         if (quickPlay.worldName != null && !quickPlay.worldName.isEmpty()) {
             String selectedWorldSaveName = quickPlay.worldName;
-            boolean hasQuickPlaySinglePlayer = instance.arguments.game.stream().anyMatch(
-                argumentRule -> argumentRule.value instanceof List &&
-                    ((List<?>) argumentRule.value).contains("--quickPlaySingleplayer")
-            );
-            if (hasQuickPlaySinglePlayer) {
+            if (instance.isQuickPlaySinglePlayerSupported()) {
                 // Only work for Minecraft 23w14a and newer versions
                 arguments.addAll(Arrays.asList("--quickPlaySingleplayer", selectedWorldSaveName));
             }
@@ -451,11 +443,7 @@ public class MCLauncher {
         // Quick Play Realm
         if (quickPlay.realmId != null && !quickPlay.realmId.isEmpty()) {
             String realmId = quickPlay.realmId;
-            boolean hasQuickPlayRealms = instance.arguments.game.stream().anyMatch(
-                argumentRule -> argumentRule.value instanceof List &&
-                    ((List<?>) argumentRule.value).contains("--quickPlayRealms")
-            );
-            if (hasQuickPlayRealms) {
+            if (instance.isQuickPlayRealmsSupported()) {
                 // Only work for Minecraft 23w14a and newer versions
                 arguments.addAll(Arrays.asList("--quickPlayRealms", realmId));
             }

--- a/src/main/java/com/atlauncher/mclauncher/MCLauncher.java
+++ b/src/main/java/com/atlauncher/mclauncher/MCLauncher.java
@@ -414,8 +414,8 @@ public class MCLauncher {
         QuickPlay quickPlay = instance.launcher.quickPlay;
 
         // Quick Play Multiplayer
-        if (quickPlay.getServerAddress() != null && !quickPlay.getServerAddress().isEmpty()) {
-            String enteredServerAddress = quickPlay.getServerAddress();
+        if (quickPlay.serverAddress != null && !quickPlay.serverAddress.isEmpty()) {
+            String enteredServerAddress = quickPlay.serverAddress;
             boolean hasQuickPlayMultiplayer = instance.arguments.game.stream().anyMatch(
                 argumentRule -> argumentRule.value instanceof List &&
                     ((List<?>) argumentRule.value).contains("--quickPlayMultiplayer")
@@ -436,8 +436,8 @@ public class MCLauncher {
         }
 
         // Quick Play Single Player
-        if (quickPlay.getWorldName() != null && !quickPlay.getWorldName().isEmpty()) {
-            String selectedWorldSaveName = quickPlay.getWorldName();
+        if (quickPlay.worldName != null && !quickPlay.worldName.isEmpty()) {
+            String selectedWorldSaveName = quickPlay.worldName;
             boolean hasQuickPlaySinglePlayer = instance.arguments.game.stream().anyMatch(
                 argumentRule -> argumentRule.value instanceof List &&
                     ((List<?>) argumentRule.value).contains("--quickPlaySingleplayer")
@@ -452,8 +452,8 @@ public class MCLauncher {
         }
 
         // Quick Play Realm
-        if (quickPlay.getRealmId() != null && !quickPlay.getRealmId().isEmpty()) {
-            String realmId = quickPlay.getRealmId();
+        if (quickPlay.realmId != null && !quickPlay.realmId.isEmpty()) {
+            String realmId = quickPlay.realmId;
             boolean hasQuickPlayRealms = instance.arguments.game.stream().anyMatch(
                 argumentRule -> argumentRule.value instanceof List &&
                     ((List<?>) argumentRule.value).contains("--quickPlayRealms")

--- a/src/main/java/com/atlauncher/mclauncher/MCLauncher.java
+++ b/src/main/java/com/atlauncher/mclauncher/MCLauncher.java
@@ -443,11 +443,8 @@ public class MCLauncher {
                     ((List<?>) argumentRule.value).contains("--quickPlaySingleplayer")
             );
             if (hasQuickPlaySinglePlayer) {
-                // Minecraft 23w14a and newer versions
+                // Only work for Minecraft 23w14a and newer versions
                 arguments.addAll(Arrays.asList("--quickPlaySingleplayer", selectedWorldSaveName));
-            } else {
-                // Minecraft 23w13a and older versions
-                // TODO: Add support for older minecraft versions (make sure to update the helper label when you do)
             }
         }
 
@@ -459,11 +456,8 @@ public class MCLauncher {
                     ((List<?>) argumentRule.value).contains("--quickPlayRealms")
             );
             if (hasQuickPlayRealms) {
-                // Minecraft 23w14a and newer versions
+                // Only work for Minecraft 23w14a and newer versions
                 arguments.addAll(Arrays.asList("--quickPlayRealms", realmId));
-            } else {
-                // Minecraft 23w13a and older versions
-                // TODO: Add support for older minecraft versions (make sure to update the helper label when you do)
             }
         }
 

--- a/src/main/java/com/atlauncher/mclauncher/MCLauncher.java
+++ b/src/main/java/com/atlauncher/mclauncher/MCLauncher.java
@@ -411,17 +411,18 @@ public class MCLauncher {
         }
 
         // Quick Play feature (with backward compatibility for older versions of Minecraft)
-        // TODO: Add support for realms and single player world later
-        QuickPlay quickPlay = instance.launcher.quickPlay;;
+        QuickPlay quickPlay = instance.launcher.quickPlay;
+
+        // Quick Play Multiplayer
         if (quickPlay.getServerAddress() != null && !quickPlay.getServerAddress().isEmpty()) {
             String enteredServerAddress = quickPlay.getServerAddress();
-            boolean hasQuickMultiplayer = instance.arguments.game.stream().anyMatch(
+            boolean hasQuickPlayMultiplayer = instance.arguments.game.stream().anyMatch(
                 argumentRule -> argumentRule.value instanceof List &&
                     ((List<?>) argumentRule.value).contains("--quickPlayMultiplayer")
             );
-            if (hasQuickMultiplayer) {
+            if (hasQuickPlayMultiplayer) {
                 // Minecraft 23w14a and newer versions
-                arguments.add("--quickPlayMultiplayer");
+                arguments.addAll(Arrays.asList("--quickPlayMultiplayer", enteredServerAddress));
                 arguments.add(enteredServerAddress);
             } else {
                 // Minecraft 23w13a and older versions
@@ -431,6 +432,38 @@ public class MCLauncher {
                 String port = parts.length > 1 ? parts[1] : String.valueOf(Constants.MINECRAFT_DEFAULT_SERVER_PORT);
                 arguments.addAll(Arrays.asList("--server", address));
                 arguments.addAll(Arrays.asList("--port", port));
+            }
+        }
+
+        // Quick Play Single Player
+        if (quickPlay.getWorldName() != null && !quickPlay.getWorldName().isEmpty()) {
+            String selectedWorldSaveName = quickPlay.getWorldName();
+            boolean hasQuickPlaySinglePlayer = instance.arguments.game.stream().anyMatch(
+                argumentRule -> argumentRule.value instanceof List &&
+                    ((List<?>) argumentRule.value).contains("--quickPlaySingleplayer")
+            );
+            if (hasQuickPlaySinglePlayer) {
+                // Minecraft 23w14a and newer versions
+                arguments.addAll(Arrays.asList("--quickPlaySingleplayer", selectedWorldSaveName));
+            } else {
+                // Minecraft 23w13a and older versions
+                // TODO: Add support for older minecraft versions (make sure to update the helper label when you do)
+            }
+        }
+
+        // Quick Play Realm
+        if (quickPlay.getRealmId() != null && !quickPlay.getRealmId().isEmpty()) {
+            String realmId = quickPlay.getRealmId();
+            boolean hasQuickPlayRealms = instance.arguments.game.stream().anyMatch(
+                argumentRule -> argumentRule.value instanceof List &&
+                    ((List<?>) argumentRule.value).contains("--quickPlayRealms")
+            );
+            if (hasQuickPlayRealms) {
+                // Minecraft 23w14a and newer versions
+                arguments.addAll(Arrays.asList("--quickPlayRealms", realmId));
+            } else {
+                // Minecraft 23w13a and older versions
+                // TODO: Add support for older minecraft versions (make sure to update the helper label when you do)
             }
         }
 

--- a/src/main/java/com/atlauncher/mclauncher/MCLauncher.java
+++ b/src/main/java/com/atlauncher/mclauncher/MCLauncher.java
@@ -37,6 +37,7 @@ import com.atlauncher.data.Instance;
 import com.atlauncher.data.LoginResponse;
 import com.atlauncher.data.MicrosoftAccount;
 import com.atlauncher.data.MojangAccount;
+import com.atlauncher.data.json.QuickPlay;
 import com.atlauncher.data.minecraft.Library;
 import com.atlauncher.data.minecraft.LoggingClient;
 import com.atlauncher.data.minecraft.PropertyMapSerializer;
@@ -409,9 +410,11 @@ public class MCLauncher {
             }
         }
 
-        // Joining a server on launch
-        if (instance.launcher.initialJoinServerAddress != null && !instance.launcher.initialJoinServerAddress.isEmpty()) {
-            String enteredServerAddress = instance.launcher.initialJoinServerAddress;
+        // Quick Play feature (with backward compatibility for older versions of Minecraft)
+        // TODO: Add support for realms and single player world later
+        QuickPlay quickPlay = instance.launcher.quickPlay;;
+        if (quickPlay.getServerAddress() != null && !quickPlay.getServerAddress().isEmpty()) {
+            String enteredServerAddress = quickPlay.getServerAddress();
             boolean hasQuickMultiplayer = instance.arguments.game.stream().anyMatch(
                 argumentRule -> argumentRule.value instanceof List &&
                     ((List<?>) argumentRule.value).contains("--quickPlayMultiplayer")

--- a/src/main/java/com/atlauncher/utils/ValidationUtils.java
+++ b/src/main/java/com/atlauncher/utils/ValidationUtils.java
@@ -1,0 +1,39 @@
+/*
+ * ATLauncher - https://github.com/ATLauncher/ATLauncher
+ * Copyright (C) 2013-2022 ATLauncher
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.atlauncher.utils;
+
+import java.util.regex.Pattern;
+
+/**
+ * A general class that contains general validations for the user input
+ */
+public class ValidationUtils {
+    /**
+     * Example of valid input:
+     * localhost,
+     * localhost:25565
+     * play.server.net
+     * play.server.net:25565
+     *
+     * @return true if the entered server address is valid, otherwise false
+     */
+    public static boolean isValidMinecraftServerAddress(String serverAddress) {
+        Pattern pattern = Pattern.compile("^([A-Za-z0-9.-]+)(:([0-9]{1,5}))?$"); // Less strict pattern
+        return pattern.matcher(serverAddress).matches();
+    }
+}

--- a/src/test/java/com/atlauncher/utils/ValidationUtilsTest.java
+++ b/src/test/java/com/atlauncher/utils/ValidationUtilsTest.java
@@ -1,0 +1,56 @@
+/*
+ * ATLauncher - https://github.com/ATLauncher/ATLauncher
+ * Copyright (C) 2013-2022 ATLauncher
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.atlauncher.utils;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import org.junit.jupiter.api.Test;
+
+public class ValidationUtilsTest {
+    @Test
+    public void testIsValidMinecraftServerAddress() {
+        // Test localhost
+        assertTrue(ValidationUtils.isValidMinecraftServerAddress("localhost"));
+        assertTrue(ValidationUtils.isValidMinecraftServerAddress("localhost:25565"));
+        assertFalse(ValidationUtils.isValidMinecraftServerAddress("localhost:255651"));
+        assertFalse(ValidationUtils.isValidMinecraftServerAddress("localhost:"));
+        assertFalse(ValidationUtils.isValidMinecraftServerAddress("localhost:invalid-port"));
+
+        // Test server address that start with a domain
+        assertTrue(ValidationUtils.isValidMinecraftServerAddress("play.server.net"));
+        assertTrue(ValidationUtils.isValidMinecraftServerAddress("play.server.net:25565"));
+        assertFalse(ValidationUtils.isValidMinecraftServerAddress("play.server.net:255651"));
+        assertFalse(ValidationUtils.isValidMinecraftServerAddress("play.server.net:"));
+        assertFalse(ValidationUtils.isValidMinecraftServerAddress("play.server.net:invalid-port"));
+
+        // Test server address that start with an ip address
+        assertTrue(ValidationUtils.isValidMinecraftServerAddress("203.0.113.123"));
+        assertTrue(ValidationUtils.isValidMinecraftServerAddress("203.0.113.123:25565"));
+        assertFalse(ValidationUtils.isValidMinecraftServerAddress("203.0.113.123:255651"));
+        assertFalse(ValidationUtils.isValidMinecraftServerAddress("203.0.113.123:"));
+        assertFalse(ValidationUtils.isValidMinecraftServerAddress("203.0.113.123:invalid-port"));
+
+        // Test server address that start with a word
+        assertTrue(ValidationUtils.isValidMinecraftServerAddress("play"));
+        assertTrue(ValidationUtils.isValidMinecraftServerAddress("play:25565"));
+        assertFalse(ValidationUtils.isValidMinecraftServerAddress("play:255651"));
+        assertFalse(ValidationUtils.isValidMinecraftServerAddress("play:"));
+        assertFalse(ValidationUtils.isValidMinecraftServerAddress("play:invalid-port"));
+    }
+}


### PR DESCRIPTION
### Go to the bottom of this PR

This will allow the player to configure the instance so that when he or she plays the game by launching the instance, it will automatically join into a Minecraft server that is specified by the user

![image](https://github.com/ATLauncher/ATLauncher/assets/73608287/01b396f8-05b7-4cd8-af3a-803fa271a502)

This feature is designed for newer Minecraft versions ([23w14a](https://www.minecraft.net/en-us/article/minecraft-snapshot-23w14a) and up) but fully compatible with `23w13a` and older versions

![image](https://github.com/ATLauncher/ATLauncher/assets/73608287/601bf7fb-2048-4d1a-84fe-9148cae7a326)

![image](https://github.com/ATLauncher/ATLauncher/assets/73608287/359bff40-865f-41b2-afa2-08aff709a883)

Feel free to ask for any changes to maintain consistency, follow the project guidelines, and make better naming or any additional changes to get the best code quality possible

The art of naming in Programming:

Should we call it `Join server after launch` instead? since it's launching the game first and then joining a server, but the current name might be preferred by users

What do you want the property to be called?

- `joinInitialServerAddress`
- `initialJoinServerAddress`
- `initialServerJoinAddress`
- `joinServerOnLaunchAddress`
- `joinServerAddress`
- `initialJoinServerAddress`
- `joinServerInitialAddress`
- `onLaunchJoinServerAddress`
- `joinServerAddress`

The list can be much larger. suggest the best name possible that fit with the variable/property naming in this project
because changing it later would require breaking changes or deprecation/migration 

This feature is inspired by another launcher that is based on MultiMC

Suggestion: When importing an instance from another launcher format, we might want to add support for this feature so if the launcher has this feature, it will import the `server address to join` property into the ATLauncher instance

Out of scope for this PR but can be used:

This will also allow Minecraft scripts like [this](https://github.com/ellet0/minecraft-sync) to update the server address property in `instance.json`so it will always be synced with the latest server

### Testing

I tested this feature with the following versions:

- `1.20.6` with and without Fabric
- `1.20.1` with and without Fabric
- `1.19.4`
- `23w13a`
- `23w14a`

I made it so that when you enter an address without a port it will use `25565` as default just like Minecraft would do it, or if you enter the full address with the port, it will also work as expected

This PR doesn't have any tests in the source code because I can't find existing tests related to the changes 

### Related Issues

- #748

### Quick Play Feature PR Update

This PR was initially created to support joining a server on the game as it's supported in the game args on both older and newer versions of Minecraft, plans have changed, I could create a new PR but then this should be approved first as the new one based on it, don't get confused by the branch name in my fork

![image](https://github.com/ATLauncher/ATLauncher/assets/73608287/e05ef1c2-f80e-472a-adf0-9628872a70b8)


In addition to everything above, I have updated this PR to include support for single-player and realm (currently work only on 23w14a and above so I left a note in the help icon but also left a TODO for adding backward compatibility so anyone can add support if needed)

I added a validation for all three inputs in to handle all the possible cases (like when the user doesn't have any world and chooses single player then tries to save the changes)

I tested the changes more, for example when selecting a world deleting the save world, and then trying to launch the game, the logic will work in a way that it won't throw an exception and instead will select a different world but needs to save the world once you select a world in the launcher, delete in the instance files, then you will get an error in the game and to fix it the player needs to go to the settings of the instance once again, select a different world (will be handled by default) then click save. this whole change in the UI would have been a lot easier if we used declarative UI like Compose desktop with Kotlin but for the current solution, we should improve the UI and separate some of the logic, extract a lot of common code, improve the naming and other important improvements before merging this PR