### PR TITLE
Chore/update gradle wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,5 @@ This changelog only contains the changes that are unreleased. For changes for in
 ### Fixes
 
 ### Misc
+
+- Update gradle wrapper version from 8.2 to 8.7 [#886](https://github.com/ATLauncher/ATLauncher/issues/886)

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
### Description of the Change

Update the gradle wrapper version from 8.2 to 8.7 which is the latest version:  https://gradle.org/releases/

This has the same changes as [#888](https://github.com/ATLauncher/ATLauncher/pull/888) but I couldn't fetch the changes in my local machine instead of GitHub web interface due to my network

### Testing

- I have tested the changes in [#893] and it seems to be working just like it should

### Related Issues

- #893
- #886 
