### PR TITLE
Ci/update application GitHub workflow

### DIFF
--- a/.github/workflows/application.yml
+++ b/.github/workflows/application.yml
@@ -1,6 +1,6 @@
 name: Application
 
-on: [push, pull_request]
+on: [ push, pull_request ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -9,15 +9,21 @@ concurrency:
 jobs:
   ci:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
 
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: "temurin"
           java-version: 8
           cache: "gradle"
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+        with:
+          validate-wrappers: true
 
       - name: Check license headers
         run: ./gradlew checkLicenses
@@ -25,21 +31,27 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     needs: ci
+    timeout-minutes: 5
     strategy:
       matrix:
-        java-version: ["8", "11", "17", "20"] # LTS + Latest
-        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        java-version: [ "8", "11", "17", "20" ] # LTS + Latest
+        os: [ "ubuntu-latest", "macos-latest", "windows-latest" ]
     name: Java ${{ matrix.java-version }} (${{ matrix.os }}) Tests
     steps:
       - uses: actions/checkout@v4
 
       - name: Set up JDK ${{ matrix.java-version }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           # MacOS (aarch64) Java 8 doesn't exist for temurin, so use zulu instead
           distribution: ${{ matrix.os =='macos-latest' && matrix.java-version == '8' && 'zulu' || 'temurin' }}
           java-version: ${{ matrix.java-version }}
           cache: "gradle"
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+        with:
+          validate-wrappers: true
 
       - name: Run Unit Tests
         run: ./gradlew --no-daemon test --tests com.atlauncher.*
@@ -52,22 +64,28 @@ jobs:
 
   build:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 5
     needs: ci
     strategy:
       matrix:
-        java-version: ["8", "11", "17", "20"] # LTS + Latest
-        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        java-version: [ "8", "11", "17", "20" ] # LTS + Latest
+        os: [ "ubuntu-latest", "macos-latest", "windows-latest" ]
     name: Java ${{ matrix.java-version }} (${{ matrix.os }}) Build
     steps:
       - uses: actions/checkout@v4
 
       - name: Set up JDK ${{ matrix.java-version }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           # MacOS (aarch64) Java 8 doesn't exist for temurin, so use zulu instead
           distribution: ${{ matrix.os =='macos-latest' && matrix.java-version == '8' && 'zulu' || 'temurin' }}
           java-version: ${{ matrix.java-version }}
           cache: "gradle"
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+        with:
+          validate-wrappers: true
 
       - name: Build
         run: ./gradlew build -x test
@@ -75,6 +93,7 @@ jobs:
   package:
     runs-on: ubuntu-latest
     needs: ci
+    timeout-minutes: 5
     outputs:
       version: ${{ steps.version.outputs.text }}
       clean-version: ${{ steps.clean-version.outputs.replaced }}
@@ -82,11 +101,16 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: "temurin"
           java-version: 8
           cache: "gradle"
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+        with:
+          validate-wrappers: true
 
       - name: Read version
         id: version
@@ -114,7 +138,8 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
-    needs: [test, build, package]
+    needs: [ test, build, package ]
+    timeout-minutes: 5
     if: ${{ github.ref == 'refs/heads/master' && !endsWith(needs.package.outputs.version, '.Beta') }}
     permissions:
       contents: write

--- a/.github/workflows/application.yml
+++ b/.github/workflows/application.yml
@@ -18,7 +18,6 @@ jobs:
         with:
           distribution: "temurin"
           java-version: 8
-          cache: "gradle"
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
@@ -46,7 +45,6 @@ jobs:
           # MacOS (aarch64) Java 8 doesn't exist for temurin, so use zulu instead
           distribution: ${{ matrix.os =='macos-latest' && matrix.java-version == '8' && 'zulu' || 'temurin' }}
           java-version: ${{ matrix.java-version }}
-          cache: "gradle"
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
@@ -80,7 +78,6 @@ jobs:
           # MacOS (aarch64) Java 8 doesn't exist for temurin, so use zulu instead
           distribution: ${{ matrix.os =='macos-latest' && matrix.java-version == '8' && 'zulu' || 'temurin' }}
           java-version: ${{ matrix.java-version }}
-          cache: "gradle"
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
@@ -105,7 +102,6 @@ jobs:
         with:
           distribution: "temurin"
           java-version: 8
-          cache: "gradle"
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,5 @@ This changelog only contains the changes that are unreleased. For changes for in
 ### Fixes
 
 ### Misc
+
+- Update the `application.yml` GitHub workflow [#889](https://github.com/ATLauncher/ATLauncher/pull/889)


### PR DESCRIPTION
### Description of the Change

This PR has the same changes as [#889](https://github.com/ATLauncher/ATLauncher/pull/889) PR

but also include the change in `CHANGELOG.md` file and format the file using IntelliJ IDEA (doesn't affect the functionality)

Note: In addition to all the notes in the previous PR, currently with this new change it's not clear that `setup-gradle` action already has to cache and shouldn't use the `setup-java` gradle cache to not cause any unexpected issues (mentioned by Gradle) in the future developers might send PRs to enable the `setup-java` action cache, and also to make it clear it already has to cache for anyone, we could either leave a comment, or we could set `cache-disabled` to false which is already by default but just to make it more clear

```yml

- name: Setup Gradle
        uses: gradle/actions/setup-gradle@v3
        with:
          validate-wrappers: true
          cache-disabled: false # To make it clear there is caching for this action, the default is already false

```



### Testing

We should be able to test it in GitHub actions directly in this PR

### Related Issues

- #889
