### PR TITLE
Feature/migrate to version catalogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,5 @@ This changelog only contains the changes that are unreleased. For changes for in
 ### Fixes
 
 ### Misc
+
+- Migrate to the new Gradle version catalogs for libraries and plugins

--- a/build.gradle
+++ b/build.gradle
@@ -21,14 +21,14 @@ plugins {
     id 'java'
     id 'application'
 
-    id 'org.cadixdev.licenser' version '0.6.1'
-    id 'com.adarshr.test-logger' version '3.2.0'
-    id 'edu.sc.seis.macAppBundle' version '2.3.0'
-    id 'edu.sc.seis.launch4j' version '3.0.3'
-    id 'de.undercouch.download' version '5.4.0'
-    id 'com.github.johnrengelman.shadow' version '8.1.1'
-    id 'com.github.ben-manes.versions' version '0.47.0'
-    id 'com.apollographql.apollo' version '2.5.14'
+    alias(libs.plugins.cadixdev.licenser)
+    alias(libs.plugins.test.logger)
+    alias(libs.plugins.mac.app.bundle)
+    alias(libs.plugins.launch4j)
+    alias(libs.plugins.undercouch.download)
+    alias(libs.plugins.shadow)
+    alias(libs.plugins.ben.manes)
+    alias(libs.plugins.apollo)
 }
 
 apply plugin: 'org.mini2Dx.gettext'
@@ -57,50 +57,50 @@ repositories {
 }
 
 dependencies {
-    implementation 'net.java.dev.jna:jna:5.13.0'
-    implementation 'net.java.dev.jna:jna-platform:5.13.0'
-    implementation 'com.google.code.gson:gson:2.10.1'
-    implementation 'com.google.guava:guava:32.1.1-jre'
-    implementation 'org.tukaani:xz:1.9'
-    implementation 'com.mojang:authlib:1.5.21'
-    implementation 'net.iharder:base64:2.3.9'
-    implementation 'com.github.Vatuu:discord-rpc:1.6.2'
-    implementation 'net.sf.jopt-simple:jopt-simple:5.0.4'
-    implementation 'org.zeroturnaround:zt-zip:1.15'
-    implementation 'com.squareup.okhttp3:okhttp:4.11.0'
-    implementation 'com.squareup.okhttp3:okhttp-tls:4.11.0'
-    implementation 'io.sentry:sentry:6.25.0'
-    implementation 'com.github.RyanTheAllmighty.gettext:gettext-lib:88ae68d897'
-    implementation 'org.apache.logging.log4j:log4j-api:2.20.0'
-    implementation 'org.apache.logging.log4j:log4j-core:2.20.0'
-    implementation 'com.sangupta:murmur:1.0.0'
-    implementation 'org.apache.commons:commons-lang3:3.12.0'
-    implementation 'org.apache.commons:commons-text:1.10.0'
-    implementation 'org.apache.commons:commons-compress:1.23.0'
-    implementation 'com.formdev:flatlaf:3.1.1'
-    implementation 'com.formdev:flatlaf-extras:3.1.1'
-    implementation 'com.github.oshi:oshi-core:6.4.4'
-    implementation 'net.freeutils:jlhttp:2.6'
-    implementation 'joda-time:joda-time:2.12.5'
-    implementation 'org.commonmark:commonmark:0.21.0'
-    implementation 'com.github.hypfvieh:dbus-java:3.3.2'
-    implementation 'com.apollographql.apollo:apollo-runtime:2.5.14'
-    implementation 'com.apollographql.apollo:apollo-http-cache:2.5.14'
-    implementation 'com.apollographql.apollo:apollo-rx3-support:2.5.14'
-    implementation 'com.github.MCRcortex:nekodetector:Version-1.1-pre'
+    implementation(libs.jna)
+    implementation(libs.jna.platform)
+    implementation(libs.gson)
+    implementation(libs.google.guava)
+    implementation(libs.xz)
+    implementation(libs.mojang.authlib)
+    implementation(libs.base64)
+    implementation(libs.discord.rpc)
+    implementation(libs.jopt.simple)
+    implementation(libs.zt.zip)
+    implementation(libs.okhttp)
+    implementation(libs.okhttp.tls)
+    implementation(libs.sentry)
+    implementation(libs.gettext.lib)
+    implementation(libs.log4j.api)
+    implementation(libs.log4j.api)
+    implementation(libs.log4j.core)
+    implementation(libs.murmur)
+    implementation(libs.commons.lang3)
+    implementation(libs.commons.text)
+    implementation(libs.commons.compress)
+    implementation(libs.flatlaf)
+    implementation(libs.flatlaf.extras)
+    implementation(libs.oshi.core)
+    implementation(libs.jlhttp)
+    implementation(libs.joda.time)
+    implementation(libs.commonmark)
+    implementation(libs.dbus.java)
+    implementation(libs.apollo.runtime)
+    implementation(libs.apollo.http.cache)
+    implementation(libs.apollo.rx3.support)
+    implementation(libs.nekodetector)
 
     // RxJava
-    implementation("io.reactivex.rxjava3:rxjava:3.1.6")
-    implementation("com.gitlab.doomsdayrs:rxswing:a5749ad421") // TODO tag
+    implementation(libs.rxjava)
+    implementation(libs.rxswing)
 
-    testImplementation 'junit:junit:4.13.2'
-    testImplementation 'org.mockito:mockito-core:4.11.0' // Cannot update to 5.x.x as Java 11 min
-    testImplementation 'org.mockito:mockito-inline:4.11.0' // Cannot update to 5.x.x as Java 11 min
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.3'
-    testImplementation 'org.assertj:assertj-swing-junit:3.17.1'
-    testImplementation 'org.mock-server:mockserver-netty:5.15.0'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.3'
-    testRuntimeOnly 'org.junit.vintage:junit-vintage-engine:5.9.3'
+    testImplementation(libs.mockito.core)
+    testImplementation(libs.mockito.inline)
+    testImplementation(libs.assertj.swing.junit)
+    testImplementation(libs.mockserver.netty)
+    testImplementation(libs.junit.jupiter.api)
+    testRuntimeOnly(libs.junit.jupiter.engine)
+    testRuntimeOnly(libs.junit.vintage.engine)
 }
 
 application {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,98 @@
+[versions]
+# Libraries
+
+jna = "5.13.0"
+gson = "2.10.1"
+google-guava = "32.1.1-jre"
+xz = "1.9"
+mojang-authlib = "1.5.21"
+base64 = "2.3.9"
+discord-rpc = "1.6.2"
+jopt-simple = "5.0.4"
+zt-zip = "1.15"
+okhttp = "4.11.0"
+sentry = "6.25.0"
+gettext-lib = "88ae68d897"
+log4j = "2.20.0"
+murmur = "1.0.0"
+commons-lang3 = "3.12.0"
+commons-text = "1.10.0"
+commons-compress = "1.23.0"
+flatlaf = "3.1.1"
+oshi-core = "6.4.4"
+jlhttp = "2.6"
+joda-time = "2.12.5"
+commonmark = "0.21.0"
+dbus-java = "3.3.2"
+apollo = "2.5.14"
+nekodetector = "Version-1.1-pre"
+rxjava = "3.1.6"
+# TODO: use tag relesae later
+rxswing = "a5749ad421"
+# Can't update to 5.x.x as Java 11 min
+mockito = "4.11.0"
+assertj-swing-junit = "3.17.1"
+mockserver-netty = "5.15.0"
+junit = "5.9.3"
+
+# Plugins
+
+cadixdev-licenser = "0.6.1"
+test-logger = "3.2.0"
+mac-app-bundle = "2.3.0"
+launch4j = "3.0.3"
+undercouch-download = "5.4.0"
+shadow = "8.1.1"
+ben-manes = "0.47.0"
+
+[libraries]
+jna = { module = "net.java.dev.jna:jna", version.ref = "jna" }
+jna-platform = { module = "net.java.dev.jna:jna-platform", version.ref = "jna" }
+gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
+google-guava = { module = "com.google.guava:guava", version.ref = "google-guava" }
+xz = { module = "org.tukaani:xz", version.ref = "xz" }
+mojang-authlib = { module = "com.mojang:authlib", version.ref = "mojang-authlib" }
+base64 = { module = "net.iharder:base64", version.ref = "base64" }
+discord-rpc = { module = "com.github.Vatuu:discord-rpc", version.ref = "discord-rpc" }
+jopt-simple = { module = "net.sf.jopt-simple:jopt-simple", version.ref = "jopt-simple" }
+zt-zip = { module = "org.zeroturnaround:zt-zip", version.ref = "zt-zip" }
+okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
+okhttp-tls = { module = "com.squareup.okhttp3:okhttp-tls", version.ref = "okhttp" }
+sentry = { module = "io.sentry:sentry", version.ref = "sentry" }
+gettext-lib = { module = "com.github.RyanTheAllmighty.gettext:gettext-lib", version.ref = "gettext-lib" }
+log4j-api = { module = "org.apache.logging.log4j:log4j-api", version.ref = "log4j" }
+log4j-core = { module = "org.apache.logging.log4j:log4j-core", version.ref = "log4j" }
+murmur = { module = "com.sangupta:murmur", version.ref = "murmur" }
+commons-lang3 = { module = "org.apache.commons:commons-lang3", version.ref = "commons-lang3" }
+commons-text = { module = "org.apache.commons:commons-text", version.ref = "commons-text" }
+commons-compress = { module = "org.apache.commons:commons-compress", version.ref = "commons-compress" }
+flatlaf = { module = "com.formdev:flatlaf", version.ref = "flatlaf" }
+flatlaf-extras = { module = "com.formdev:flatlaf-extras", version.ref = "flatlaf" }
+oshi-core = { module = "com.github.oshi:oshi-core", version.ref = "oshi-core" }
+jlhttp = { module = "net.freeutils:jlhttp", version.ref = "jlhttp" }
+joda-time = { module = "joda-time:joda-time", version.ref = "joda-time" }
+commonmark = { module = "org.commonmark:commonmark", version.ref = "commonmark" }
+dbus-java = { module = "com.github.hypfvieh:dbus-java", version.ref = "dbus-java" }
+apollo-runtime = { module = "com.apollographql.apollo:apollo-runtime", version.ref = "apollo" }
+apollo-http-cache = { module = "com.apollographql.apollo:apollo-http-cache", version.ref = "apollo" }
+apollo-rx3-support = { module = "com.apollographql.apollo:apollo-rx3-support", version.ref = "apollo" }
+nekodetector = { module = "com.github.MCRcortex:nekodetector", version.ref = "nekodetector" }
+rxjava = { module = "io.reactivex.rxjava3:rxjava", version.ref = "rxjava" }
+rxswing = { module = "com.gitlab.doomsdayrs:rxswing", version.ref = "rxswing" }
+mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }
+mockito-inline = { module = "org.mockito:mockito-inline", version.ref = "mockito" }
+assertj-swing-junit = { module = "org.assertj:assertj-swing-junit", version.ref = "assertj-swing-junit" }
+mockserver-netty = { module = "org.mock-server:mockserver-netty", version.ref = "mockserver-netty" }
+junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit" }
+junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit" }
+junit-vintage-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit" }
+
+[plugins]
+cadixdev-licenser = { id = "org.cadixdev.licenser", version.ref = "cadixdev-licenser" }
+test-logger = { id = "com.adarshr.test-logger", version.ref = "test-logger" }
+mac-app-bundle = { id = "edu.sc.seis.macAppBundle", version.ref = "mac-app-bundle" }
+launch4j = { id = "edu.sc.seis.launch4j", version.ref = "launch4j" }
+undercouch-download = { id = "de.undercouch.download", version.ref = "undercouch-download" }
+shadow = { id = "com.github.johnrengelman.shadow", version.ref = "shadow" }
+ben-manes = { id = "com.github.ben-manes.versions", version.ref = "ben-manes" }
+apollo = { id = "com.apollographql.apollo", version.ref = "apollo" }


### PR DESCRIPTION
### Use the new Gradle Version catalogs without breaking or changing anything

This PR aims to migrate to the new [Gradle version catalogs](https://docs.gradle.org/current/userguide/platforms.html) without changing or breaking anything for the final application and it did just that, you might think it's unnecessary, let me give a few reasons why we might want to migrate to this

If you are unfamiliar with it, see [Android Guide](https://developer.android.com/build/migrate-to-catalogs), [Gradle Guide](https://docs.gradle.org/current/userguide/platforms.html) or [Medium Guide](https://medium.com/@callmeryan/gradle-version-catalog-728111fa210f)

1. Consistency: This will allow us to use the same versions and libraries with auto-completion for all modules
2. The new standard: Not just new Android projects already use this, but even when creating a new project with Gradle, Kotlin, KMP (Kotlin Multi-Platform) and almost all projects that use Gradle are moving to this
3. Better Readability: We no longer have to focus on the versions while changing anything in Gradle configurations. If we want, we can just go to the file `gradle/libs.versions.toml
4. Better Compatibility and Adoption: All new scripts and tools will focus more on this instead of the old way of doing things
5. Manage all the project versions: all from one place. If you make a typo or mistake, you will probably know it before  syncing the project
6. Reduce merge conflicts: and not just this, using the latest tools gives developers more reasons and passion to contribute to projects
7. Share versions in an effective way and efficient: And not just between libraries (by creating a variable that will make the project harder to maintain) and even allow you to share versions between libraries and plugins, I shared the `apollo` version between the libraries that are being used and the apollo plugin, if anyone wants to update it, we can from one place for better combability and solve unnecessary issues earlier
8. Better scalability

I made those changes with care and not using scripts or other automation tools, for example:

1. Correct naming even if the module name is not very clear, for example, the module name `com.mojang:authlib` will be `authlib` if it was automated and the module name in this case is simply not very clear, I named it `mojang-authlib` instead
2. Remove the old `junit` library. If you take a look at this [link](https://mvnrepository.com/artifact/junit/junit) you will see 
> This artifact was moved to: org.junit.jupiter » junit-jupiter-api
and the project is still using the old and the new test library

I removed the duplication and shared the version between all `junit` libraries that have the exact same version

3. Moved all the comments and todo to the correct new place and improved them for consistency, like the todo that says `// TODO tag version` I simply updated it to `# TODO: use tag release later` because all todos in this project usually start with `TODO: ` or the comment `Can't update to 5.x.x as Java 11 min` for `mockito`
4. Shared some of the versions, some libraries like `mockito-core` and `mockito-inline` has the exact same version so I used one version variable for that,`log4j` or `apollo` (`apollo-runtime`, `apollo-http-cache`, `apollo-rx3-support`) which also has a grade plugin that uses the exact same version, other libraries like `flatlaf` and `flatlaf-extras` also share the version and more
5. The order of the implementations is a little bit more organized. Some libraries that come from the same developer or it's an extension for it, or share the version are now moved to be closer

Next steps:

1. Use this more, for example, in the `buildscript`, but it's not needed
2. Update some of the libraries that have security issues or are outdated
3. Migrate to Gradle KTS which can be quicker than this PR and is the new default even for Java projects when creating a project using Gradle and not just IntelliJ IDEA, Kotlin, or Android, and it depends on Gradle Groovy, a better syntax and more type-safe, easier and more built-in functions, much easier to maintain and the only reason why Gradle still mention Groovy in the docs because many old projects still using it
4. The `app` module is not found, and it's still included in `settings.gradle.kts`
5. Move from GSON to [Kotlinx Selrizlation](https://github.com/Kotlin/kotlinx.serialization) (can work with JVM Projects and not just Kotlin) which has better performance as it's compiled time and not using reflection, more type safety, and many other features like support for formats other than Json in the same library and configurations, work with different targets (Kotlin/Native, JVM, and even JS), less code and more result, easier to use, custom serialization, compatibility with existing Gson code although moving it manually is not that hard, more active development (There is no newer version for Gson since 2023 January) and large projects start using it and more features, GSON was very good for a long time

The list can be bigger

### Testing

All the tests have passed, and the build works without any issues or new warnings at least, I tested both the launcher and the game even though it's not needed since this change doesn't affect the user experience or the actual/final application in any way, it doesn't has any semantic change

### Related Issues

I couldn't find any
