### PR TITLE
Feature/mac os dark and light themes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This changelog only contains the changes that are unreleased. For changes for in
 ## 3.4.36.5
 
 ### New Features
+- Add the option to use macOS dark and light themes [#901]
 
 ### Fixes
 

--- a/src/main/java/com/atlauncher/App.java
+++ b/src/main/java/com/atlauncher/App.java
@@ -798,7 +798,7 @@ public class App {
             setLAF(theme);
             modifyLAF();
 
-            // now the theme is loaded, we can intialize the toaster/tray menu
+            // now the theme is loaded, we can initialize the toaster/tray menu
             TOASTER = Toaster.instance();
             TRAY_MENU = new TrayMenu();
         } catch (Exception ex) {

--- a/src/main/java/com/atlauncher/gui/tabs/settings/GeneralSettingsTab.java
+++ b/src/main/java/com/atlauncher/gui/tabs/settings/GeneralSettingsTab.java
@@ -137,6 +137,8 @@ public class GeneralSettingsTab extends AbstractSettingsTab {
         theme.addItem(new ComboItem<>("com.atlauncher.themes.CyanLight", "Cyan Light"));
         theme.addItem(new ComboItem<>("com.atlauncher.themes.HighTechDarkness", "High Tech Darkness"));
         theme.addItem(new ComboItem<>("com.atlauncher.themes.OneDark", "One Dark"));
+        theme.addItem(new ComboItem<>("com.atlauncher.themes.MacOsDark", "macOS Dark"));
+        theme.addItem(new ComboItem<>("com.atlauncher.themes.MacOsLight", "macOS Light"));
 
         for (int i = 0; i < theme.getItemCount(); i++) {
             ComboItem<String> item = theme.getItemAt(i);

--- a/src/main/java/com/atlauncher/themes/ATLauncherLaf.java
+++ b/src/main/java/com/atlauncher/themes/ATLauncherLaf.java
@@ -39,6 +39,7 @@ import com.formdev.flatlaf.FlatDarkLaf;
 import com.formdev.flatlaf.FlatIntelliJLaf;
 import com.formdev.flatlaf.FlatLaf;
 import com.formdev.flatlaf.FlatLightLaf;
+import com.formdev.flatlaf.themes.FlatMacDarkLaf;
 
 @SuppressWarnings("serial")
 public class ATLauncherLaf extends FlatLaf {
@@ -137,6 +138,10 @@ public class ATLauncherLaf extends FlatLaf {
         return false;
     }
 
+    public boolean isMacOS() {
+        return false;
+    }
+
     @Override
     public List<Class<?>> getLafClassesForDefaultsLoading() {
         List<Class<?>> classes = new ArrayList<>();
@@ -150,11 +155,18 @@ public class ATLauncherLaf extends FlatLaf {
             if (isIntelliJTheme()) {
                 classes.add(FlatDarculaLaf.class);
             }
+
+            if (isMacOS()) {
+                classes.add(FlatMacDarkLaf.class);
+            }
         } else {
             classes.add(FlatLightLaf.class);
 
             if (isIntelliJTheme()) {
                 classes.add(FlatIntelliJLaf.class);
+            }
+            if (isMacOS()) {
+                classes.add(FlatMacDarkLaf.class);
             }
         }
 

--- a/src/main/java/com/atlauncher/themes/MacOsDark.java
+++ b/src/main/java/com/atlauncher/themes/MacOsDark.java
@@ -1,0 +1,2 @@
+package com.atlauncher.themes;public class MacOsDark {
+}

--- a/src/main/java/com/atlauncher/themes/MacOsDark.java
+++ b/src/main/java/com/atlauncher/themes/MacOsDark.java
@@ -1,2 +1,42 @@
-package com.atlauncher.themes;public class MacOsDark {
+/*
+ * ATLauncher - https://github.com/ATLauncher/ATLauncher
+ * Copyright (C) 2013-2022 ATLauncher
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.atlauncher.themes;
+
+public class MacOsDark extends Dark {
+
+    public static boolean install() {
+        instance = new MacOsDark();
+
+        return setup(instance);
+    }
+
+    @Override
+    public String getName() {
+        return "macOS Dark";
+    }
+
+    @Override
+    public String getDescription() {
+        return "macOS Dark of ATLauncher";
+    }
+
+    @Override
+    public boolean isMacOS() {
+        return true;
+    }
 }

--- a/src/main/java/com/atlauncher/themes/MacOsLight.java
+++ b/src/main/java/com/atlauncher/themes/MacOsLight.java
@@ -1,0 +1,2 @@
+package com.atlauncher.themes;public class MacOsLight {
+}

--- a/src/main/java/com/atlauncher/themes/MacOsLight.java
+++ b/src/main/java/com/atlauncher/themes/MacOsLight.java
@@ -1,2 +1,42 @@
-package com.atlauncher.themes;public class MacOsLight {
+/*
+ * ATLauncher - https://github.com/ATLauncher/ATLauncher
+ * Copyright (C) 2013-2022 ATLauncher
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.atlauncher.themes;
+
+public class MacOsLight extends Light {
+
+    public static boolean install() {
+        instance = new MacOsLight();
+
+        return setup(instance);
+    }
+
+    @Override
+    public String getName() {
+        return "macOS Light";
+    }
+
+    @Override
+    public String getDescription() {
+        return "macOS Light of ATLauncher";
+    }
+
+    @Override
+    public boolean isMacOS() {
+        return true;
+    }
 }


### PR DESCRIPTION
### Description of the Change

This PR doesn't do much, it makes use of the macOS themes provided by [FlatLaf](https://github.com/JFormDesigner/FlatLaf) library

I could improve the way of loading the themes in a more modern and type-safe way but this is out of the scope of this PR, does ATLauncher support downloading themes or using themes other than the one built-in in the application?

### Testing

![image](https://github.com/ATLauncher/ATLauncher/assets/73608287/7ce6aa02-5723-4eb0-b0f0-ac065a173675)

Using the light theme would make the text of the console window a little bit unreadable:
![image](https://github.com/ATLauncher/ATLauncher/assets/73608287/427e31db-ec11-4294-8867-228e931fccee)

But the same issue applies to some other light themes:
![image](https://github.com/ATLauncher/ATLauncher/assets/73608287/6151dda7-38e2-4139-a337-c9a0a80c3b88)


### Related Issues

- Cloe #901
- [#JDK-8235363](https://bugs.openjdk.org/browse/JDK-8235363)

### Important

This change won't get the full theme of `FlatMacDarkLaf` and `FlatMacDarkLaf` just like the image in issue #901 due to the way themes are loaded, see the two images and compare them and you will see what I mean (in my opinion the image in #901 looks better than the one in this PR), let me know if you know about a solution, but I suggest to refactor the way how we are using themes (without breaking changes or change the underline data),