### PR TITLE
misc: Use lambda in legacy launch MCFrame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,3 +23,4 @@ This changelog only contains the changes that are unreleased. For changes for in
 - Mojang Account support completely removed [#907]
 - Update versions of Java tested in GitHub workflows
 - Update dependencies
+- Use lambda in legacy launch MCFrame [#911]

--- a/legacy-launch/src/main/java/com/atlauncher/mclauncher/legacy/MCFrame.java
+++ b/legacy-launch/src/main/java/com/atlauncher/mclauncher/legacy/MCFrame.java
@@ -44,18 +44,15 @@ public class MCFrame extends Frame {
 
         this.addWindowListener(new WindowAdapter() {
             public void windowClosing(WindowEvent windowEvent) {
-                new Thread() {
-                    @Override
-                    public void run() {
-                        try {
-                            Thread.sleep(30000L);
-                        } catch (InterruptedException ignored) {
-                            Thread.currentThread().interrupt();
-                            return;
-                        }
-                        System.exit(0);
+                new Thread(() -> {
+                    try {
+                        Thread.sleep(30000L);
+                    } catch (InterruptedException ignored) {
+                        Thread.currentThread().interrupt();
+                        return;
                     }
-                }.start();
+                    System.exit(0);
+                }).start();
 
                 if (appletWrap != null) {
                     appletWrap.stop();


### PR DESCRIPTION
### Description of the Change

Use lambda in legacy launch MCFrame

### Testing

- N/A, this only uses a java feature in code.