### PR TITLE
feat: Add version option for CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This changelog only contains the changes that are unreleased. For changes for in
 ### New Features
 - Add AboutTab [#568]
 - Add the option to join a minecraft server, world, and realm when launching an instance [#748]
+- Add version option for CLI [#915]
 
 ### Fixes
 - Issue exporting/disabling/deleting worlds downloaded from CurseForge [#927]

--- a/src/main/java/com/atlauncher/App.java
+++ b/src/main/java/com/atlauncher/App.java
@@ -1003,6 +1003,10 @@ public class App {
         parser.accepts("config-override", "A JSON string to override the launchers config.").withRequiredArg()
                 .ofType(String.class);
         parser.acceptsAll(Arrays.asList("help", "?"), "Shows help for the arguments for the application.").forHelp();
+        parser
+            .acceptsAll(Arrays.asList("version", "v"), "Shows the launcher version")
+            .withOptionalArg()
+            .ofType(Boolean.class);
 
         OptionSet options = parser.parse(args);
         autoLaunch = options.has("launch") ? (String) options.valueOf("launch") : null;
@@ -1014,6 +1018,11 @@ public class App {
                 e1.printStackTrace();
             }
 
+            System.exit(0);
+        }
+
+        if (options.has("version")) {
+            System.out.printf("%s %s\n", Constants.LAUNCHER_NAME, Constants.VERSION.toStringForLogging());
             System.exit(0);
         }
 


### PR DESCRIPTION
### Description of the Change

Add version option for CLI.

### Testing

- [x] Execute jar normally
- [x] Execute jar with: `-v`, `--v`,  `--version` 

### Related Issues

Closes #914