### PR TITLE
Feature/updated support for instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This changelog only contains the changes that are unreleased. For changes for in
 - Use NeoForge server start jar to allow launching servers using our scripts (partially) [#921]
 - Add a readme file when creating servers using our scripts
 - Add prompt to update outdated Java [#930]
+- Try to get support links for CurseForge packs from description and from overrides
 
 ### Fixes
 - Issue exporting/disabling/deleting worlds downloaded from CurseForge [#927]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This changelog only contains the changes that are unreleased. For changes for in
 - Add a readme file when creating servers using our scripts
 - Add prompt to update outdated Java [#930]
 - Try to get support links for CurseForge packs from description and from overrides
+- Prompt to visit last instance that crashed when trying to visit ATLauncher Discord
 
 ### Fixes
 - Issue exporting/disabling/deleting worlds downloaded from CurseForge [#927]

--- a/src/main/java/com/atlauncher/Launcher.java
+++ b/src/main/java/com/atlauncher/Launcher.java
@@ -29,6 +29,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -41,6 +42,7 @@ import org.mini2Dx.gettext.GetText;
 import com.atlauncher.builders.HTMLBuilder;
 import com.atlauncher.constants.Constants;
 import com.atlauncher.data.DownloadableFile;
+import com.atlauncher.data.Instance;
 import com.atlauncher.data.LauncherVersion;
 import com.atlauncher.graphql.AddLauncherLaunchMutation;
 import com.atlauncher.graphql.type.AddLauncherLaunchInput;
@@ -91,6 +93,8 @@ public class Launcher {
     // Minecraft tracking variables
     private Process minecraftProcess = null; // The process minecraft is running on
     public boolean minecraftLaunched = false; // If Minecraft has been Launched
+    public Instance lastInstanceCrash = null; // The last instance that crashed
+    public Date lastInstanceCrashTime = null; // The time the last instance crashed
 
     public void loadEverything() {
         PerformanceManager.start();
@@ -488,6 +492,8 @@ public class Launcher {
 
     public void showKillMinecraft(Process minecraft) {
         this.minecraftProcess = minecraft;
+        this.lastInstanceCrash = null;
+        this.lastInstanceCrashTime = null;
         App.console.showKillMinecraft();
     }
 
@@ -508,5 +514,10 @@ public class Launcher {
         } else {
             LogManager.error("Cannot kill Minecraft as there is no instance open!");
         }
+    }
+
+    public void setLastInstanceCrash(Instance instance) {
+        this.lastInstanceCrash = instance;
+        this.lastInstanceCrashTime = new Date();
     }
 }

--- a/src/main/java/com/atlauncher/data/Instance.java
+++ b/src/main/java/com/atlauncher/data/Instance.java
@@ -156,6 +156,7 @@ import com.atlauncher.utils.ArchiveUtils;
 import com.atlauncher.utils.ComboItem;
 import com.atlauncher.utils.CommandExecutor;
 import com.atlauncher.utils.CurseForgeApi;
+import com.atlauncher.utils.CurseForgeUtils;
 import com.atlauncher.utils.FileUtils;
 import com.atlauncher.utils.Hashing;
 import com.atlauncher.utils.Java;
@@ -3240,7 +3241,8 @@ public class Instance extends MinecraftVersion {
 
     public List<String> getSinglePlayerWorldNamesFromFilesystem() {
         File[] folders = ROOT.resolve("saves").toFile().listFiles((dir, name) -> new File(dir, name).isDirectory());
-        if (folders == null) return new ArrayList<>();
+        if (folders == null)
+            return new ArrayList<>();
         return Arrays.stream(folders).map(File::getName).collect(Collectors.toList());
     }
 
@@ -3249,9 +3251,8 @@ public class Instance extends MinecraftVersion {
             return false;
         }
         return arguments.game.stream().anyMatch(
-            argumentRule -> argumentRule.value instanceof List &&
-                ((List<?>) argumentRule.value).contains(quickPlayOption.argumentRuleValue)
-        );
+                argumentRule -> argumentRule.value instanceof List &&
+                        ((List<?>) argumentRule.value).contains(quickPlayOption.argumentRuleValue));
     }
 
     private List<Path> getModPathsFromFilesystem() {
@@ -3530,6 +3531,37 @@ public class Instance extends MinecraftVersion {
 
         if (isModrinthPack()) {
             return launcher.modrinthProject.discordUrl;
+        }
+
+        if (isCurseForgePack()) {
+            if (launcher.curseForgeProjectDescription != null) {
+                String discordLinkFromDescription = CurseForgeUtils
+                        .parseDescriptionForDiscordInvite(launcher.curseForgeProjectDescription);
+                if (discordLinkFromDescription != null) {
+                    return discordLinkFromDescription;
+                }
+            }
+
+            // allow overriding the discord link from ATLauncher's side
+            String overriddenDiscordLink = ConfigManager
+                    .<String>getConfigItem(
+                            "discordLinkMatching.curseForgeProjectIdsToDiscordLink." + launcher.curseForgeProject.id,
+                            null);
+            if (overriddenDiscordLink != null) {
+                return overriddenDiscordLink;
+            }
+
+            // allow overriding the discord link from ATLauncher's side for an author
+            if (launcher.curseForgeProject.authors != null && !launcher.curseForgeProject.authors.isEmpty()) {
+                String overriddenDiscordLinkForAuthor = ConfigManager
+                        .<String>getConfigItem(
+                                "discordLinkMatching.curseForgeAuthorIdsToDiscordLink."
+                                        + launcher.curseForgeProject.authors.get(0).id,
+                                null);
+                if (overriddenDiscordLinkForAuthor != null) {
+                    return overriddenDiscordLinkForAuthor;
+                }
+            }
         }
 
         return null;

--- a/src/main/java/com/atlauncher/data/InstanceLauncher.java
+++ b/src/main/java/com/atlauncher/data/InstanceLauncher.java
@@ -87,6 +87,7 @@ public class InstanceLauncher {
     public CurseForgeManifest curseForgeManifest;
 
     public CurseForgeProject curseForgeProject;
+    public String curseForgeProjectDescription = null;
     public CurseForgeFile curseForgeFile;
     public MultiMCManifest multiMCManifest;
     public ModrinthProject modrinthProject;

--- a/src/main/java/com/atlauncher/data/Pack.java
+++ b/src/main/java/com/atlauncher/data/Pack.java
@@ -62,6 +62,7 @@ public class Pack {
     public boolean hasDiscordImage;
     public String description;
     public CurseForgeProject curseForgeProject;
+    public String curseForgeProjectDescription = null;
     public ModpacksChPackManifest modpacksChPack;
     public ModrinthProject modrinthProject;
     public TechnicModpack technicModpack;

--- a/src/main/java/com/atlauncher/gui/card/InstanceCard.java
+++ b/src/main/java/com/atlauncher/gui/card/InstanceCard.java
@@ -158,7 +158,7 @@ public class InstanceCard extends CollapsiblePanel implements RelocalizationList
     public InstanceCard(Instance instance, boolean hasUpdate, String instanceTitleFormat) {
         super(instance, instanceTitleFormat);
         this.instance = instance;
-        this.image = new ImagePanel(()-> instance.getImage().getImage());
+        this.image = new ImagePanel(() -> instance.getImage().getImage());
         this.hasUpdate = hasUpdate;
 
         JSplitPane splitter = new JSplitPane();
@@ -198,13 +198,13 @@ public class InstanceCard extends CollapsiblePanel implements RelocalizationList
 
         top.add(this.playButton);
         top.add(this.updateButton);
+        top.add(this.getHelpButton);
         top.add(this.editInstanceButton);
         top.add(this.backupButton);
         top.add(this.settingsButton);
 
         bottom.add(this.deleteButton);
         bottom.add(this.exportButton);
-        bottom.add(this.getHelpButton);
 
         setupPlayPopupMenus();
         setupOpenPopupMenus();

--- a/src/main/java/com/atlauncher/gui/components/BottomBar.java
+++ b/src/main/java/com/atlauncher/gui/components/BottomBar.java
@@ -20,15 +20,23 @@ package com.atlauncher.gui.components;
 import java.awt.BorderLayout;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
+import java.util.Date;
 
 import javax.swing.BorderFactory;
 import javax.swing.JButton;
 import javax.swing.JPanel;
 import javax.swing.UIManager;
 
+import org.mini2Dx.gettext.GetText;
+
+import com.atlauncher.App;
+import com.atlauncher.builders.HTMLBuilder;
 import com.atlauncher.evnt.listener.ThemeListener;
 import com.atlauncher.evnt.manager.ThemeManager;
+import com.atlauncher.managers.DialogManager;
 import com.atlauncher.managers.LogManager;
+import com.atlauncher.network.Analytics;
+import com.atlauncher.network.analytics.AnalyticsEvent;
 import com.atlauncher.utils.OS;
 
 public abstract class BottomBar extends JPanel implements ThemeListener {
@@ -67,6 +75,24 @@ public abstract class BottomBar extends JPanel implements ThemeListener {
             OS.openWebBrowser("https://atl.pw/nodecraft-from-launcher");
         });
         discordIcon.addActionListener(e -> {
+            if (App.launcher.lastInstanceCrashTime != null && App.launcher.lastInstanceCrash != null
+                    && new Date().getTime() - App.launcher.lastInstanceCrashTime.getTime() < 300000
+                    && App.launcher.lastInstanceCrash.getDiscordInviteUrl() != null) {
+                int ret = DialogManager.yesNoDialog(false).setTitle(GetText.tr("Visit Modpack Discord?"))
+                        .setContent(new HTMLBuilder().center().text(GetText.tr(
+                                "Would you like to open the Discord server for the last instance that crashed?"))
+                                .build())
+                        .setType(DialogManager.QUESTION).show();
+
+                if (ret == DialogManager.YES_OPTION) {
+                    Analytics.trackEvent(AnalyticsEvent.forInstanceEvent("instance_crashed_discord_button",
+                            App.launcher.lastInstanceCrash));
+                    LogManager.info("Opening Up Discord for Modpack");
+                    OS.openWebBrowser(App.launcher.lastInstanceCrash.getDiscordInviteUrl());
+                    return;
+                }
+            }
+
             LogManager.info("Opening Up ATLauncher Discord");
             OS.openWebBrowser("https://atl.pw/discord");
         });

--- a/src/main/java/com/atlauncher/utils/CurseForgeApi.java
+++ b/src/main/java/com/atlauncher/utils/CurseForgeApi.java
@@ -236,6 +236,25 @@ public class CurseForgeApi {
         return null;
     }
 
+    public static String getProjectDescription(int projectId) {
+        String url = String.format(Locale.ENGLISH, "%s/mods/%d/description?raw=true", Constants.CURSEFORGE_CORE_API_URL,
+                projectId);
+
+        Download download = Download.build().setUrl(url).header("x-api-key", Constants.CURSEFORGE_CORE_API_KEY)
+                .cached(new CacheControl.Builder().maxStale(1, TimeUnit.HOURS).build());
+
+        java.lang.reflect.Type type = new TypeToken<CurseForgeCoreApiResponse<String>>() {
+        }.getType();
+
+        CurseForgeCoreApiResponse<String> response = download.asType(type);
+
+        if (response != null) {
+            return response.data;
+        }
+
+        return null;
+    }
+
     public static CurseForgeProject getProjectById(int projectId) {
         return getProjectById(Integer.toString(projectId));
     }

--- a/src/main/java/com/atlauncher/utils/CurseForgeUtils.java
+++ b/src/main/java/com/atlauncher/utils/CurseForgeUtils.java
@@ -1,0 +1,58 @@
+/*
+ * ATLauncher - https://github.com/ATLauncher/ATLauncher
+ * Copyright (C) 2013-2022 ATLauncher
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.atlauncher.utils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.jetbrains.annotations.Nullable;
+
+import com.atlauncher.managers.ConfigManager;
+
+/**
+ * Various utility methods for working with CurseForge information.
+ */
+public class CurseForgeUtils {
+    @Nullable
+    public static String parseDescriptionForDiscordInvite(String description) {
+        if (description == null) {
+            return null;
+        }
+
+        List<String> customDiscordLinks = ConfigManager
+                .getConfigItem("discordLinkMatching.customLinks", new ArrayList<String>());
+        Optional<String> foundDiscordLink = customDiscordLinks.stream().filter(link -> description.contains(link))
+                .findFirst();
+        if (foundDiscordLink.isPresent()) {
+            return "https://" + foundDiscordLink.get();
+        }
+
+        // try parse out discord.gg links
+        Pattern pattern = Pattern.compile("(https:\\/\\/discord\\.(?:gg|com\\/invite)\\/[a-zA-Z0-9]+)");
+        Matcher matcher = pattern.matcher(description);
+
+        if (!matcher.find()) {
+            return null;
+        }
+
+        return matcher.group(1);
+    }
+}

--- a/src/main/java/com/atlauncher/workers/InstanceInstaller.java
+++ b/src/main/java/com/atlauncher/workers/InstanceInstaller.java
@@ -2144,6 +2144,7 @@ public class InstanceInstaller extends SwingWorker<Boolean, Void> implements Net
             instanceLauncher.requiredPermGen = this.packVersion.permGen;
             instanceLauncher.assetsMapToResources = this.assetsMapToResources;
             instanceLauncher.curseForgeProject = this.pack.curseForgeProject;
+            instanceLauncher.curseForgeProjectDescription = this.pack.curseForgeProjectDescription;
             instanceLauncher.curseForgeFile = this.version._curseForgeFile;
             instanceLauncher.multiMCManifest = multiMCManifest;
             instanceLauncher.modrinthProject = this.pack.modrinthProject;

--- a/src/test/java/com/atlauncher/utils/CurseForgeUtilsTest.java
+++ b/src/test/java/com/atlauncher/utils/CurseForgeUtilsTest.java
@@ -1,0 +1,68 @@
+/*
+ * ATLauncher - https://github.com/ATLauncher/ATLauncher
+ * Copyright (C) 2013-2022 ATLauncher
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.atlauncher.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mockStatic;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.atlauncher.managers.ConfigManager;
+
+public class CurseForgeUtilsTest {
+    @Test
+    public void testParseDescriptionForDiscordInvite() {
+        // Test with no discord links
+        assertNull(CurseForgeUtils.parseDescriptionForDiscordInvite("This is a test description"));
+
+        // Test with discord links
+        assertEquals("https://discord.gg/example", CurseForgeUtils
+                .parseDescriptionForDiscordInvite("This is a test description https://discord.gg/example"));
+        assertEquals("https://discord.com/invite/example", CurseForgeUtils
+                .parseDescriptionForDiscordInvite("This is a test description https://discord.com/invite/example"));
+
+        // Test with multiple discord links only gets the first one
+        assertEquals("https://discord.gg/example", CurseForgeUtils.parseDescriptionForDiscordInvite(
+                "This is a test description https://discord.gg/example https://discord.gg/example2"));
+        assertEquals("https://discord.com/invite/example", CurseForgeUtils.parseDescriptionForDiscordInvite(
+                "This is a test description https://discord.com/invite/example https://discord.com/invite/example2"));
+
+        // Test with custom links
+
+        try (MockedStatic<ConfigManager> utilities = mockStatic(ConfigManager.class)) {
+            utilities
+                    .when(() -> ConfigManager.getConfigItem("discordLinkMatching.customLinks", new ArrayList<String>()))
+                    .thenReturn(Arrays.asList("example.com/discord"));
+
+            assertEquals("https://example.com/discord", CurseForgeUtils.parseDescriptionForDiscordInvite(
+                    "This is a test description https://example.com/discord"));
+
+            utilities
+                    .when(() -> ConfigManager.getConfigItem("discordLinkMatching.customLinks", new ArrayList<String>()))
+                    .thenReturn(Arrays.asList("example.com/link/discord"));
+
+            assertNull(CurseForgeUtils.parseDescriptionForDiscordInvite(
+                    "This is a test description https://example.com/discord"));
+        }
+    }
+}


### PR DESCRIPTION
This adds in lookup for CurseForge modpacks Discord links from their packs description on CurseForge, as well as links we explicitely define in the backend to link project and author ids from CurseForge to a support discord url.

The main issue we see in the Discord is people coming to our Discord for support with their broken modpacks.

Modrinth allow packs to define Discord and support urls, but CurseForge do not, so this is to try and alleviate those links not being shown in the launcher.

This also tracks when an instance crashes, and if the user within 5 minutes uses the Discord buttons on the launcher, it will prompt them to go to the packs discord first. This is again to try and alleviate the number of people coming to ATLauncher Discord for pack issues.