### PR TITLE
fix: [#715] attempt to fix popup dialogs causing other application windows to not be responsive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This changelog only contains the changes that are unreleased. For changes for in
 - Issue installing Modrinth pack with invalid filename [#923]
 - Issue with launching servers with a space in the name not removing Java path correctly on Windows
 - Remove warnings on too much memory being allocated
+- Attempt to fix popup dialogs causing other application windows to not be responsive [#715]
 
 ### Misc
 - Speed up CreatePackTab [#933]

--- a/src/main/java/com/atlauncher/managers/DialogManager.java
+++ b/src/main/java/com/atlauncher/managers/DialogManager.java
@@ -187,13 +187,43 @@ public final class DialogManager {
 
     public int show() {
         try {
-            return JOptionPane.showOptionDialog(this.getParent(), this.content, this.title, this.lookAndFeel, this.type,
-                    this.icon, this.getOptions(), this.defaultOption);
+            Object[] options = this.getOptions();
+
+            JOptionPane jop = new JOptionPane(this.content, this.type, this.lookAndFeel, this.icon, options,
+                    this.defaultOption);
+
+            jop.setInitialValue(this.defaultOption);
+            jop.setComponentOrientation(this.getParent().getComponentOrientation());
+
+            JDialog dialog = jop.createDialog(this.getParent(), this.title);
+            dialog.setAlwaysOnTop(true);
+            dialog.setVisible(true);
+
+            Object selectedValue = jop.getValue();
+
+            if (selectedValue == null) {
+                return CLOSED_OPTION;
+            }
+
+            if (options == null) {
+                if (selectedValue instanceof Integer) {
+                    return ((Integer) selectedValue).intValue();
+                }
+                return CLOSED_OPTION;
+            }
+
+            for (int counter = 0, maxCounter = options.length; counter < maxCounter; counter++) {
+                if (options[counter].equals(selectedValue)) {
+                    return counter;
+                }
+            }
+
+            return CLOSED_OPTION;
         } catch (Exception e) {
             LogManager.logStackTrace(e, false);
         }
 
-        return -1;
+        return CLOSED_OPTION;
     }
 
     public int showWithFileMonitoring(File firstFile, File secondFile, int size, int returnValue) {


### PR DESCRIPTION
This one has been a growing issue for a while.

It cannot be replicated easily to confirm the fix works, so this is really just a best effort guess at a potential fix by creating the JOptionPane ourselves for dialogs and then setting the dialog to show always on top rather than using the convenience methods.

This may or may not work, but given the difficulty to try and replicate the issue, it's about all I have