### PR TITLE
Feature/gh 942 sinytra mods on forge like

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This changelog only contains the changes that are unreleased. For changes for in
 - Use NeoForge server start jar to allow launching servers using our scripts (partially) [#921]
 - Add a readme file when creating servers using our scripts
 - Add prompt to update outdated Java [#930]
+- Allow installing Fabric mods to Forge and NeoForge instances when Sinytra Connector is installed [#942]
 
 ### Fixes
 - Issue exporting/disabling/deleting worlds downloaded from CurseForge [#927]

--- a/src/main/java/com/atlauncher/constants/Constants.java
+++ b/src/main/java/com/atlauncher/constants/Constants.java
@@ -94,6 +94,8 @@ public class Constants {
     public static final int CURSEFORGE_FABRIC_MOD_ID = 306612;
     public static final int CURSEFORGE_LEGACY_FABRIC_MOD_ID = 400281;
     public static final int CURSEFORGE_JUMPLOADER_MOD_ID = 361988;
+    public static final int CURSEFORGE_SINYTRA_CONNECTOR_MOD_ID = 890127;
+    public static final int CURSEFORGE_FORGIFIED_FABRIC_API_MOD_ID = 889079;
     public static final int CURSEFORGE_MODS_SECTION_ID = 6;
     public static final int CURSEFORGE_MODPACKS_SECTION_ID = 4471;
     public static final int CURSEFORGE_RESOURCE_PACKS_SECTION_ID = 12;
@@ -106,6 +108,8 @@ public class Constants {
     public static final String MODRINTH_FABRIC_MOD_ID = "P7dR8mSH";
     public static final String MODRINTH_LEGACY_FABRIC_MOD_ID = "9CJED7xi";
     public static final String MODRINTH_QSL_MOD_ID = "qvIfYCYJ";
+    public static final String MODRINTH_SINYTRA_CONNECTOR_MOD_ID = "u58R1TMW";
+    public static final String MODRINTH_FORGIFIED_FABRIC_API_MOD_ID = "Aqlf1Shp";
     public static final int MODRINTH_PAGINATION_SIZE = 20;
 
     // Modpacks.ch domains, endpoints, config, etc

--- a/src/main/java/com/atlauncher/data/Instance.java
+++ b/src/main/java/com/atlauncher/data/Instance.java
@@ -3240,7 +3240,8 @@ public class Instance extends MinecraftVersion {
 
     public List<String> getSinglePlayerWorldNamesFromFilesystem() {
         File[] folders = ROOT.resolve("saves").toFile().listFiles((dir, name) -> new File(dir, name).isDirectory());
-        if (folders == null) return new ArrayList<>();
+        if (folders == null)
+            return new ArrayList<>();
         return Arrays.stream(folders).map(File::getName).collect(Collectors.toList());
     }
 
@@ -3249,9 +3250,8 @@ public class Instance extends MinecraftVersion {
             return false;
         }
         return arguments.game.stream().anyMatch(
-            argumentRule -> argumentRule.value instanceof List &&
-                ((List<?>) argumentRule.value).contains(quickPlayOption.argumentRuleValue)
-        );
+                argumentRule -> argumentRule.value instanceof List &&
+                        ((List<?>) argumentRule.value).contains(quickPlayOption.argumentRuleValue));
     }
 
     private List<Path> getModPathsFromFilesystem() {
@@ -3614,5 +3614,17 @@ public class Instance extends MinecraftVersion {
 
         // #. {0} is the name of a mod that was removed
         App.TOASTER.pop(GetText.tr("{0} Removed", foundMod.name));
+    }
+
+    public boolean isForgeLikeAndHasInstalledSinytraConnector() {
+        if (launcher.loaderVersion == null || !(launcher.loaderVersion.isForge()
+                || launcher.loaderVersion.isNeoForge())) {
+            return false;
+        }
+
+        return launcher.mods.stream().anyMatch(m -> (m.isFromCurseForge()
+                && m.getCurseForgeModId() == Constants.CURSEFORGE_SINYTRA_CONNECTOR_MOD_ID)
+                || m.isFromModrinth()
+                        && m.modrinthProject.id.equalsIgnoreCase(Constants.MODRINTH_SINYTRA_CONNECTOR_MOD_ID));
     }
 }

--- a/src/main/java/com/atlauncher/data/Instance.java
+++ b/src/main/java/com/atlauncher/data/Instance.java
@@ -3625,6 +3625,7 @@ public class Instance extends MinecraftVersion {
         return launcher.mods.stream().anyMatch(m -> (m.isFromCurseForge()
                 && m.getCurseForgeModId() == Constants.CURSEFORGE_SINYTRA_CONNECTOR_MOD_ID)
                 || m.isFromModrinth()
-                        && m.modrinthProject.id.equalsIgnoreCase(Constants.MODRINTH_SINYTRA_CONNECTOR_MOD_ID));
+                        && m.modrinthProject.id.equalsIgnoreCase(Constants.MODRINTH_SINYTRA_CONNECTOR_MOD_ID))
+                && App.settings.showFabricModsWhenSinytraInstalled;
     }
 }

--- a/src/main/java/com/atlauncher/data/Settings.java
+++ b/src/main/java/com/atlauncher/data/Settings.java
@@ -89,6 +89,7 @@ public class Settings {
     public ModPlatform defaultModPlatform = ModPlatform.CURSEFORGE;
     public AddModRestriction addModRestriction = AddModRestriction.STRICT;
     public boolean enableAddedModsByDefault = true;
+    public boolean showFabricModsWhenSinytraInstalled = true;
     public boolean allowCurseForgeAlphaBetaFiles = false;
     public boolean dontCheckModsOnCurseForge = false;
     public boolean dontCheckModsOnModrinth = false;

--- a/src/main/java/com/atlauncher/gui/dialogs/AddModsDialog.java
+++ b/src/main/java/com/atlauncher/gui/dialogs/AddModsDialog.java
@@ -135,6 +135,18 @@ public final class AddModsDialog extends JDialog {
                             "Quilt", "Quilt Standard Libraries")
                     + "</p></html>");
 
+    // #. {0} is the loader api (Fabric API/QSL)
+    private final JButton installForgifiedFabricApiButton = new JButton(
+            GetText.tr("Install {0}", "Forgified Fabric API"));
+
+    private final JLabel forgifiedFabricApiWarningLabel = new JLabel(
+            "<html><p align=\"center\" style=\"color: "
+                    + String.format("#%06x", 0xFFFFFF & UIManager.getColor("yellow").getRGB())
+                    // #. {0} is the loader (Fabric/Quilt), {1} is the loader api (Fabric API/QSL)
+                    + "\">" + GetText.tr("Before installing {0} mods, you should install {1} first!",
+                            "Fabric", "Forgified Fabric API")
+                    + "</p></html>");
+
     private JScrollPane jscrollPane;
     private JButton nextButton;
     private JButton prevButton;
@@ -215,6 +227,11 @@ public final class AddModsDialog extends JDialog {
 
         this.topPanel.setBorder(BorderFactory.createEmptyBorder(0, 10, 0, 10));
 
+        fabricApiWarningLabel.setBorder(BorderFactory.createEmptyBorder(10, 0, 10, 0));
+        legacyFabricApiWarningLabel.setBorder(BorderFactory.createEmptyBorder(10, 0, 10, 0));
+        quiltStandardLibrariesWarningLabel.setBorder(BorderFactory.createEmptyBorder(10, 0, 10, 0));
+        forgifiedFabricApiWarningLabel.setBorder(BorderFactory.createEmptyBorder(10, 0, 10, 0));
+
         JPanel searchButtonsPanel = new JPanel();
 
         searchButtonsPanel.setLayout(new BoxLayout(searchButtonsPanel, BoxLayout.X_AXIS));
@@ -252,11 +269,11 @@ public final class AddModsDialog extends JDialog {
 
                 if (mod == null) {
                     // #. {0} is the loader api were getting info from (Fabric/Quilt)
-                    DialogManager.okDialog().setTitle(GetText.tr("Error Getting {0} Information"))
+                    DialogManager.okDialog().setTitle(GetText.tr("Error Getting {0} Information", "Fabric API"))
                             // #. {0} is the loader (Fabric/Quilt) {1} is the platform (CurseForge/Modrinth)
                             .setContent(new HTMLBuilder().center().text(GetText.tr(
                                     "There was an error getting {0} information from {1}. Please try again later.",
-                                    "CurseForge"))
+                                    "Fabric API", "CurseForge"))
                                     .build())
                             .setType(DialogManager.ERROR).show();
                     return;
@@ -293,10 +310,11 @@ public final class AddModsDialog extends JDialog {
 
                 if (mod == null) {
                     // #. {0} is the loader api were getting info from (Fabric/Quilt)
-                    DialogManager.okDialog().setTitle(GetText.tr("Error Getting {0} Information"))
+                    DialogManager.okDialog().setTitle(GetText.tr("Error Getting {0} Information", "Fabric API"))
                             // #. {0} is the loader (Fabric/Quilt) {1} is the platform (CurseForge/Modrinth)
                             .setContent(new HTMLBuilder().center().text(GetText.tr(
                                     "There was an error getting {0} information from {1}. Please try again later.",
+                                    "Fabric API",
                                     "Modrinth"))
                                     .build())
                             .setType(DialogManager.ERROR).show();
@@ -346,10 +364,11 @@ public final class AddModsDialog extends JDialog {
 
                 if (mod == null) {
                     // #. {0} is the loader api were getting info from (Fabric/Quilt)
-                    DialogManager.okDialog().setTitle(GetText.tr("Error Getting {0} Information"))
+                    DialogManager.okDialog().setTitle(GetText.tr("Error Getting {0} Information", "Legacy Fabric API"))
                             // #. {0} is the loader (Fabric/Quilt) {1} is the platform (CurseForge/Modrinth)
                             .setContent(new HTMLBuilder().center().text(GetText.tr(
                                     "There was an error getting {0} information from {1}. Please try again later.",
+                                    "Legacy Fabric API",
                                     "CurseForge"))
                                     .build())
                             .setType(DialogManager.ERROR).show();
@@ -389,10 +408,11 @@ public final class AddModsDialog extends JDialog {
 
                 if (mod == null) {
                     // #. {0} is the loader api were getting info from (Fabric/Quilt)
-                    DialogManager.okDialog().setTitle(GetText.tr("Error Getting {0} Information"))
+                    DialogManager.okDialog().setTitle(GetText.tr("Error Getting {0} Information", "Legacy Fabric API"))
                             // #. {0} is the loader (Fabric/Quilt) {1} is the platform (CurseForge/Modrinth)
                             .setContent(new HTMLBuilder().center().text(GetText.tr(
                                     "There was an error getting {0} information from {1}. Please try again later.",
+                                    "Legacy Fabric API",
                                     "Modrinth"))
                                     .build())
                             .setType(DialogManager.ERROR).show();
@@ -463,6 +483,107 @@ public final class AddModsDialog extends JDialog {
             }
         });
 
+        this.installForgifiedFabricApiButton.addActionListener(e -> {
+            boolean isCurseForge = ((ComboItem<ModPlatform>) hostComboBox.getSelectedItem())
+                    .getValue() == ModPlatform.CURSEFORGE;
+            if (isCurseForge) {
+                final ProgressDialog<CurseForgeProject> curseForgeProjectLookupDialog = new ProgressDialog<>(
+                        // #. {0} is the loader api were getting info from (Fabric/Quilt)
+                        GetText.tr("Getting {0} Information", "Forgified Fabric API"), 0,
+                        // #. {0} is the loader api were getting info from (Fabric/Quilt)
+                        GetText.tr("Getting {0} Information", "Forgified Fabric API"),
+                        "Aborting Getting Forgified Fabric API Information");
+
+                curseForgeProjectLookupDialog.addThread(new Thread(() -> {
+                    curseForgeProjectLookupDialog
+                            .setReturnValue(
+                                    CurseForgeApi.getProjectById(Constants.CURSEFORGE_FORGIFIED_FABRIC_API_MOD_ID));
+
+                    curseForgeProjectLookupDialog.close();
+                }));
+
+                curseForgeProjectLookupDialog.start();
+
+                CurseForgeProject mod = curseForgeProjectLookupDialog.getReturnValue();
+
+                if (mod == null) {
+                    // #. {0} is the loader api were getting info from (Fabric/Quilt)
+                    DialogManager.okDialog()
+                            .setTitle(GetText.tr("Error Getting {0} Information", "Forgified Fabric API"))
+                            // #. {0} is the loader (Fabric/Quilt) {1} is the platform (CurseForge/Modrinth)
+                            .setContent(new HTMLBuilder().center().text(GetText.tr(
+                                    "There was an error getting {0} information from {1}. Please try again later.",
+                                    "Forgified Fabric API", "CurseForge"))
+                                    .build())
+                            .setType(DialogManager.ERROR).show();
+                    return;
+                }
+
+                Analytics.trackEvent(AnalyticsEvent.forAddMod("Forgified Fabric API", "CurseForge"));
+                new CurseForgeProjectFileSelectorDialog(this, mod, instance);
+
+                if (instance.launcher.mods.stream().anyMatch(
+                        m -> (m.isFromCurseForge()
+                                && m.getCurseForgeModId() == Constants.CURSEFORGE_FORGIFIED_FABRIC_API_MOD_ID)
+                                || (m.isFromModrinth()
+                                        && m.modrinthProject.id
+                                                .equalsIgnoreCase(Constants.MODRINTH_FORGIFIED_FABRIC_API_MOD_ID)))) {
+                    forgifiedFabricApiWarningLabel.setVisible(false);
+                    installForgifiedFabricApiButton.setVisible(false);
+                }
+            } else {
+                final ProgressDialog<ModrinthProject> modrinthProjectLookupDialog = new ProgressDialog<>(
+                        // #. {0} is the loader api were getting info from (Fabric/Quilt)
+                        GetText.tr("Getting {0} Information", "Fabric API"), 0,
+                        // #. {0} is the loader api were getting info from (Fabric/Quilt)
+                        GetText.tr("Getting {0} Information", "Fabric API"),
+                        "Aborting Getting Fabric API Information");
+
+                modrinthProjectLookupDialog.addThread(new Thread(() -> {
+                    modrinthProjectLookupDialog
+                            .setReturnValue(ModrinthApi.getProject(Constants.MODRINTH_FORGIFIED_FABRIC_API_MOD_ID));
+
+                    modrinthProjectLookupDialog.close();
+                }));
+
+                modrinthProjectLookupDialog.start();
+
+                ModrinthProject mod = modrinthProjectLookupDialog.getReturnValue();
+
+                if (mod == null) {
+                    // #. {0} is the loader api were getting info from (Fabric/Quilt)
+                    DialogManager.okDialog()
+                            .setTitle(GetText.tr("Error Getting {0} Information", "Forgified Fabric API"))
+                            // #. {0} is the loader (Fabric/Quilt) {1} is the platform (CurseForge/Modrinth)
+                            .setContent(new HTMLBuilder().center().text(GetText.tr(
+                                    "There was an error getting {0} information from {1}. Please try again later.",
+                                    "Forgified Fabric API", "Modrinth"))
+                                    .build())
+                            .setType(DialogManager.ERROR).show();
+                    return;
+                }
+
+                Analytics.trackEvent(AnalyticsEvent.forAddMod("Forgified Fabric API", "Modrinth"));
+                new ModrinthVersionSelectorDialog(this, mod, instance);
+
+                if (instance.launcher.mods.stream().anyMatch(
+                        m -> (m.isFromCurseForge()
+                                && m.getCurseForgeModId() == Constants.CURSEFORGE_FORGIFIED_FABRIC_API_MOD_ID)
+                                || (m.isFromModrinth()
+                                        && m.modrinthProject.id
+                                                .equalsIgnoreCase(Constants.MODRINTH_FORGIFIED_FABRIC_API_MOD_ID)))) {
+                    forgifiedFabricApiWarningLabel.setVisible(false);
+                    installForgifiedFabricApiButton.setVisible(false);
+                }
+            }
+
+            if (searchField.getText().isEmpty()) {
+                loadDefaultMods();
+            } else {
+                searchForMods();
+            }
+        });
+
         LoaderVersion loaderVersion = this.instance.launcher.loaderVersion;
 
         if (loaderVersion != null && loaderVersion.isFabric() && instance.launcher.mods.stream()
@@ -491,6 +612,18 @@ public final class AddModsDialog extends JDialog {
                         && m.modrinthProject.id.equalsIgnoreCase(Constants.MODRINTH_QSL_MOD_ID))) {
             this.topPanel.add(quiltStandardLibrariesWarningLabel, BorderLayout.CENTER);
             this.topPanel.add(installQuiltStandardLibrariesButton, BorderLayout.EAST);
+        }
+
+        // If on Forge/NeoForge and has Sinytra Connector installed, then show Forgified
+        // Fabric API things
+        if (instance.isForgeLikeAndHasInstalledSinytraConnector() && instance.launcher.mods.stream()
+                .noneMatch(m -> (m.isFromCurseForge()
+                        && m.getCurseForgeModId() == Constants.CURSEFORGE_FORGIFIED_FABRIC_API_MOD_ID)
+                        || m.isFromModrinth()
+                                && m.modrinthProject.id
+                                        .equalsIgnoreCase(Constants.MODRINTH_FORGIFIED_FABRIC_API_MOD_ID))) {
+            this.topPanel.add(forgifiedFabricApiWarningLabel, BorderLayout.CENTER);
+            this.topPanel.add(installForgifiedFabricApiButton, BorderLayout.EAST);
         }
 
         this.topPanel.add(searchButtonsPanel, BorderLayout.NORTH);
@@ -720,6 +853,19 @@ public final class AddModsDialog extends JDialog {
                                 ((ComboItem<String>) sortComboBox.getSelectedItem()).getValue(),
                                 ((ComboItem<String>) categoriesComboBox.getSelectedItem()) == null ? null
                                         : ((ComboItem<String>) categoriesComboBox.getSelectedItem()).getValue()));
+                    } else if (this.instance.isForgeLikeAndHasInstalledSinytraConnector()) {
+                        if (this.instance.launcher.loaderVersion.isForge()) {
+                            setCurseForgeMods(CurseForgeApi.searchModsForForgeOrFabric(versionToSearchFor, query, page,
+                                    ((ComboItem<String>) sortComboBox.getSelectedItem()).getValue(),
+                                    ((ComboItem<String>) categoriesComboBox.getSelectedItem()) == null ? null
+                                            : ((ComboItem<String>) categoriesComboBox.getSelectedItem()).getValue()));
+                        } else {
+                            setCurseForgeMods(CurseForgeApi.searchModsForNeoForgeOrFabric(versionToSearchFor, query,
+                                    page,
+                                    ((ComboItem<String>) sortComboBox.getSelectedItem()).getValue(),
+                                    ((ComboItem<String>) categoriesComboBox.getSelectedItem()) == null ? null
+                                            : ((ComboItem<String>) categoriesComboBox.getSelectedItem()).getValue()));
+                        }
                     } else if (this.instance.launcher.loaderVersion.isForge()) {
                         setCurseForgeMods(CurseForgeApi.searchModsForForge(versionToSearchFor, query, page,
                                 ((ComboItem<String>) sortComboBox.getSelectedItem()).getValue(),
@@ -776,6 +922,18 @@ public final class AddModsDialog extends JDialog {
                                 ((ComboItem<String>) sortComboBox.getSelectedItem()).getValue(),
                                 ((ComboItem<String>) categoriesComboBox.getSelectedItem()) == null ? null
                                         : ((ComboItem<String>) categoriesComboBox.getSelectedItem()).getValue()));
+                    } else if (this.instance.isForgeLikeAndHasInstalledSinytraConnector()) {
+                        if (this.instance.launcher.loaderVersion.isForge()) {
+                            setModrinthMods(ModrinthApi.searchModsForForgeOrFabric(versionsToSearchFor, query, page,
+                                    ((ComboItem<String>) sortComboBox.getSelectedItem()).getValue(),
+                                    ((ComboItem<String>) categoriesComboBox.getSelectedItem()) == null ? null
+                                            : ((ComboItem<String>) categoriesComboBox.getSelectedItem()).getValue()));
+                        } else {
+                            setModrinthMods(ModrinthApi.searchModsForNeoForgeOrFabric(versionsToSearchFor, query, page,
+                                    ((ComboItem<String>) sortComboBox.getSelectedItem()).getValue(),
+                                    ((ComboItem<String>) categoriesComboBox.getSelectedItem()) == null ? null
+                                            : ((ComboItem<String>) categoriesComboBox.getSelectedItem()).getValue()));
+                        }
                     } else if (this.instance.launcher.loaderVersion.isForge()) {
                         setModrinthMods(ModrinthApi.searchModsForForge(versionsToSearchFor, query, page,
                                 ((ComboItem<String>) sortComboBox.getSelectedItem()).getValue(),
@@ -855,6 +1013,11 @@ public final class AddModsDialog extends JDialog {
                         if (castMod.id == Constants.CURSEFORGE_LEGACY_FABRIC_MOD_ID) {
                             legacyFabricApiWarningLabel.setVisible(true);
                             installLegacyFabricApiButton.setVisible(true);
+                        }
+
+                        if (castMod.id == Constants.CURSEFORGE_FORGIFIED_FABRIC_API_MOD_ID) {
+                            forgifiedFabricApiWarningLabel.setVisible(true);
+                            installForgifiedFabricApiButton.setVisible(true);
                         }
                     }
                 }), gbc);
@@ -940,6 +1103,11 @@ public final class AddModsDialog extends JDialog {
                         if (castMod.projectId.equals(Constants.MODRINTH_QSL_MOD_ID)) {
                             quiltStandardLibrariesWarningLabel.setVisible(true);
                             installQuiltStandardLibrariesButton.setVisible(true);
+                        }
+
+                        if (castMod.projectId.equals(Constants.MODRINTH_FORGIFIED_FABRIC_API_MOD_ID)) {
+                            forgifiedFabricApiWarningLabel.setVisible(true);
+                            installForgifiedFabricApiButton.setVisible(true);
                         }
                     }
                 }), gbc);

--- a/src/main/java/com/atlauncher/gui/dialogs/CurseForgeProjectFileSelectorDialog.java
+++ b/src/main/java/com/atlauncher/gui/dialogs/CurseForgeProjectFileSelectorDialog.java
@@ -256,6 +256,14 @@ public class CurseForgeProjectFileSelectorDialog extends JDialog {
                                     return true;
                                 }
 
+                                // don't show CurseForge dependency when grabbed from Modrinth
+                                if (dependency.modId == Constants.CURSEFORGE_FORGIFIED_FABRIC_API_MOD_ID
+                                        && installedMod.isFromModrinth()
+                                        && installedMod.modrinthProject.id
+                                                .equals(Constants.MODRINTH_FORGIFIED_FABRIC_API_MOD_ID)) {
+                                    return true;
+                                }
+
                                 return installedMod.isFromCurseForge()
                                         && installedMod.getCurseForgeModId() == dependency.modId;
                             }))
@@ -321,7 +329,8 @@ public class CurseForgeProjectFileSelectorDialog extends JDialog {
                 curseForgeFilesStream = curseForgeFilesStream.filter(cf -> {
                     if (cf.gameVersions.contains("Fabric") && loaderVersion != null
                             && (loaderVersion.isFabric() || loaderVersion.isLegacyFabric()
-                                    || loaderVersion.isQuilt())) {
+                                    || loaderVersion.isQuilt()
+                                    || this.instance.isForgeLikeAndHasInstalledSinytraConnector())) {
                         return true;
                     }
 

--- a/src/main/java/com/atlauncher/gui/dialogs/CurseForgeProjectFileSelectorDialog.java
+++ b/src/main/java/com/atlauncher/gui/dialogs/CurseForgeProjectFileSelectorDialog.java
@@ -231,7 +231,16 @@ public class CurseForgeProjectFileSelectorDialog extends JDialog {
         if (selectedFile.dependencies.size() != 0) {
             // check to see which required ones we don't already have
             List<CurseForgeFileDependency> dependencies = selectedFile.dependencies.stream()
-                    .filter(dependency -> dependency.isRequired() && instance.launcher.mods.stream()
+                    .filter(dependency -> dependency.isRequired())
+                    .filter(dependency -> {
+                        if (dependency.modId != Constants.CURSEFORGE_FABRIC_MOD_ID) {
+                            return true;
+                        }
+
+                        // We shouldn't install Fabric API when using Sinytra Connector
+                        return !instance.isForgeLikeAndHasInstalledSinytraConnector();
+                    })
+                    .filter(dependency -> instance.launcher.mods.stream()
                             .noneMatch(installedMod -> {
                                 if (instance.getLoaderVersion().isQuilt()
                                         && dependency.modId == Constants.CURSEFORGE_FABRIC_MOD_ID) {

--- a/src/main/java/com/atlauncher/gui/dialogs/ModrinthVersionSelectorDialog.java
+++ b/src/main/java/com/atlauncher/gui/dialogs/ModrinthVersionSelectorDialog.java
@@ -175,6 +175,14 @@ public class ModrinthVersionSelectorDialog extends JDialog {
                                             return true;
                                         }
 
+                                        // don't show Modrinth dependency when grabbed from CurseForge
+                                        if (dependency.projectId.equals(Constants.MODRINTH_FORGIFIED_FABRIC_API_MOD_ID)
+                                                && installedMod.isFromCurseForge()
+                                                && installedMod
+                                                        .getCurseForgeFileId() == Constants.CURSEFORGE_FORGIFIED_FABRIC_API_MOD_ID) {
+                                            return true;
+                                        }
+
                                         return installedMod.isFromModrinth()
                                                 && installedMod.modrinthProject.id.equals(dependency.projectId);
                                     }))
@@ -373,7 +381,8 @@ public class ModrinthVersionSelectorDialog extends JDialog {
                 modrinthVersionsStream = modrinthVersionsStream.filter(v -> {
                     if (v.loaders.contains("fabric") && (this.instance.launcher.loaderVersion.isFabric()
                             || this.instance.launcher.loaderVersion.isLegacyFabric()
-                            || this.instance.launcher.loaderVersion.isQuilt())) {
+                            || this.instance.launcher.loaderVersion.isQuilt()
+                            || this.instance.isForgeLikeAndHasInstalledSinytraConnector())) {
                         return true;
                     }
 

--- a/src/main/java/com/atlauncher/gui/dialogs/ModrinthVersionSelectorDialog.java
+++ b/src/main/java/com/atlauncher/gui/dialogs/ModrinthVersionSelectorDialog.java
@@ -378,11 +378,19 @@ public class ModrinthVersionSelectorDialog extends JDialog {
                     && mod.projectType == ModrinthProjectType.MOD) {
                 List<String> neoForgeForgeCompatabilityVersions = ConfigManager
                         .getConfigItem("loaders.neoforge.forgeCompatibleMinecraftVersions", new ArrayList<String>());
+                boolean hasNeoForgeVersion = this.versionsData.stream()
+                        .anyMatch(v -> v.loaders.contains("neoforge")
+                                || (neoForgeForgeCompatabilityVersions.contains(this.instance.id)
+                                        && v.loaders.contains("forge")));
+                boolean hasForgeVersion = this.versionsData.stream().anyMatch(v -> v.loaders.contains("forge"));
                 modrinthVersionsStream = modrinthVersionsStream.filter(v -> {
                     if (v.loaders.contains("fabric") && (this.instance.launcher.loaderVersion.isFabric()
                             || this.instance.launcher.loaderVersion.isLegacyFabric()
                             || this.instance.launcher.loaderVersion.isQuilt()
-                            || this.instance.isForgeLikeAndHasInstalledSinytraConnector())) {
+                            || (this.instance.isForgeLikeAndHasInstalledSinytraConnector()
+                                    && this.instance.launcher.loaderVersion.isForge() && !hasForgeVersion)
+                            || (this.instance.isForgeLikeAndHasInstalledSinytraConnector()
+                                    && this.instance.launcher.loaderVersion.isNeoForge() && !hasNeoForgeVersion))) {
                         return true;
                     }
 

--- a/src/main/java/com/atlauncher/gui/dialogs/ModrinthVersionSelectorDialog.java
+++ b/src/main/java/com/atlauncher/gui/dialogs/ModrinthVersionSelectorDialog.java
@@ -148,44 +148,52 @@ public class ModrinthVersionSelectorDialog extends JDialog {
         if (dependencies.size() != 0) {
             // check to see which required ones we don't already have
             List<ModrinthDependency> dependenciesNeeded = dependencies.stream()
-                    .filter(dependency -> dependency.dependencyType == ModrinthDependencyType.REQUIRED
-                            && instance.launcher.mods.stream()
-                                    .noneMatch(installedMod -> {
-                                        // don't show Modrinth dependency when grabbed from CurseForge
-                                        if (dependency.projectId.equals(Constants.MODRINTH_FABRIC_MOD_ID)
-                                                && installedMod.isFromCurseForge()
-                                                && installedMod
-                                                        .getCurseForgeFileId() == Constants.CURSEFORGE_FABRIC_MOD_ID) {
-                                            return true;
-                                        }
+                    .filter(dependency -> dependency.dependencyType == ModrinthDependencyType.REQUIRED)
+                    .filter(dependency -> {
+                        if (!dependency.projectId.equals(Constants.MODRINTH_FABRIC_MOD_ID)) {
+                            return true;
+                        }
 
-                                        // don't show Modrinth dependency when grabbed from CurseForge
-                                        if (dependency.projectId.equals(Constants.MODRINTH_LEGACY_FABRIC_MOD_ID)
-                                                && installedMod.isFromCurseForge()
-                                                && installedMod
-                                                        .getCurseForgeFileId() == Constants.CURSEFORGE_LEGACY_FABRIC_MOD_ID) {
-                                            return true;
-                                        }
+                        // We shouldn't install Fabric API when using Sinytra Connector
+                        return !instance.isForgeLikeAndHasInstalledSinytraConnector();
+                    })
+                    .filter(dependency -> instance.launcher.mods.stream()
+                            .noneMatch(installedMod -> {
+                                // don't show Modrinth dependency when grabbed from CurseForge
+                                if (dependency.projectId.equals(Constants.MODRINTH_FABRIC_MOD_ID)
+                                        && installedMod.isFromCurseForge()
+                                        && installedMod
+                                                .getCurseForgeFileId() == Constants.CURSEFORGE_FABRIC_MOD_ID) {
+                                    return true;
+                                }
 
-                                        // don't show Fabric dependency when QSL is installed
-                                        if (dependency.projectId.equals(Constants.MODRINTH_FABRIC_MOD_ID)
-                                                && installedMod.isFromModrinth()
-                                                && installedMod.modrinthProject.id
-                                                        .equals(Constants.MODRINTH_QSL_MOD_ID)) {
-                                            return true;
-                                        }
+                                // don't show Modrinth dependency when grabbed from CurseForge
+                                if (dependency.projectId.equals(Constants.MODRINTH_LEGACY_FABRIC_MOD_ID)
+                                        && installedMod.isFromCurseForge()
+                                        && installedMod
+                                                .getCurseForgeFileId() == Constants.CURSEFORGE_LEGACY_FABRIC_MOD_ID) {
+                                    return true;
+                                }
 
-                                        // don't show Modrinth dependency when grabbed from CurseForge
-                                        if (dependency.projectId.equals(Constants.MODRINTH_FORGIFIED_FABRIC_API_MOD_ID)
-                                                && installedMod.isFromCurseForge()
-                                                && installedMod
-                                                        .getCurseForgeFileId() == Constants.CURSEFORGE_FORGIFIED_FABRIC_API_MOD_ID) {
-                                            return true;
-                                        }
+                                // don't show Fabric dependency when QSL is installed
+                                if (dependency.projectId.equals(Constants.MODRINTH_FABRIC_MOD_ID)
+                                        && installedMod.isFromModrinth()
+                                        && installedMod.modrinthProject.id
+                                                .equals(Constants.MODRINTH_QSL_MOD_ID)) {
+                                    return true;
+                                }
 
-                                        return installedMod.isFromModrinth()
-                                                && installedMod.modrinthProject.id.equals(dependency.projectId);
-                                    }))
+                                // don't show Modrinth dependency when grabbed from CurseForge
+                                if (dependency.projectId.equals(Constants.MODRINTH_FORGIFIED_FABRIC_API_MOD_ID)
+                                        && installedMod.isFromCurseForge()
+                                        && installedMod
+                                                .getCurseForgeFileId() == Constants.CURSEFORGE_FORGIFIED_FABRIC_API_MOD_ID) {
+                                    return true;
+                                }
+
+                                return installedMod.isFromModrinth()
+                                        && installedMod.modrinthProject.id.equals(dependency.projectId);
+                            }))
                     .collect(Collectors.toList());
 
             if (dependenciesNeeded.size() != 0) {

--- a/src/main/java/com/atlauncher/gui/tabs/settings/ModsSettingsTab.java
+++ b/src/main/java/com/atlauncher/gui/tabs/settings/ModsSettingsTab.java
@@ -38,6 +38,7 @@ public class ModsSettingsTab extends AbstractSettingsTab {
     private final JComboBox<ComboItem<ModPlatform>> defaultModPlatform;
     private final JComboBox<ComboItem<AddModRestriction>> addModRestriction;
     private final JCheckBox enableAddedModsByDefault;
+    private final JCheckBox showFabricModsWhenSinytraInstalled;
     private final JCheckBox allowCurseForgeAlphaBetaFiles;
     private final JCheckBox dontCheckModsOnCurseForge;
     private final JCheckBox dontCheckModsOnModrinth;
@@ -126,6 +127,24 @@ public class ModsSettingsTab extends AbstractSettingsTab {
         enableAddedModsByDefault = new JCheckBox();
         enableAddedModsByDefault.setSelected(App.settings.enableAddedModsByDefault);
         add(enableAddedModsByDefault, gbc);
+
+        // Show Fabric Mods When Sinytra Installed
+
+        gbc.gridx = 0;
+        gbc.gridy++;
+        gbc.insets = UIConstants.LABEL_INSETS;
+        gbc.anchor = GridBagConstraints.BASELINE_TRAILING;
+        JLabelWithHover showFabricModsWhenSinytraInstalledLabel = new JLabelWithHover(GetText.tr("Show Fabric Mods When Sinytra Installed?"),
+                HELP_ICON, new HTMLBuilder().center().split(100)
+                        .text(GetText.tr("When Sinytra Connector is installed, should Fabric mods be shown?")).build());
+        add(showFabricModsWhenSinytraInstalledLabel, gbc);
+
+        gbc.gridx++;
+        gbc.insets = UIConstants.CHECKBOX_FIELD_INSETS;
+        gbc.anchor = GridBagConstraints.BASELINE_LEADING;
+        showFabricModsWhenSinytraInstalled = new JCheckBox();
+        showFabricModsWhenSinytraInstalled.setSelected(App.settings.showFabricModsWhenSinytraInstalled);
+        add(showFabricModsWhenSinytraInstalled, gbc);
 
         // Allow CurseForge Alpha/Beta CurseForge files
 
@@ -239,6 +258,7 @@ public class ModsSettingsTab extends AbstractSettingsTab {
         App.settings.addModRestriction = ((ComboItem<AddModRestriction>) addModRestriction.getSelectedItem())
                 .getValue();
         App.settings.enableAddedModsByDefault = enableAddedModsByDefault.isSelected();
+        App.settings.showFabricModsWhenSinytraInstalled = showFabricModsWhenSinytraInstalled.isSelected();
         App.settings.allowCurseForgeAlphaBetaFiles = allowCurseForgeAlphaBetaFiles.isSelected();
         App.settings.dontCheckModsOnCurseForge = dontCheckModsOnCurseForge.isSelected();
         App.settings.dontCheckModsOnModrinth = dontCheckModsOnModrinth.isSelected();

--- a/src/main/java/com/atlauncher/utils/CurseForgeApi.java
+++ b/src/main/java/com/atlauncher/utils/CurseForgeApi.java
@@ -181,12 +181,40 @@ public class CurseForgeApi {
                 modLoaderTypes, sort, categoryIdParam);
     }
 
+    public static List<CurseForgeProject> searchModsForForgeOrFabric(String gameVersion, String query, int page,
+            String sort,
+            String categoryId) {
+        Integer categoryIdParam = categoryId == null ? null : Integer.parseInt(categoryId);
+        List<Integer> modLoaderTypes = Arrays.asList(Constants.CURSEFORGE_FORGE_MODLOADER_ID,
+                Constants.CURSEFORGE_FABRIC_MODLOADER_ID);
+
+        return searchCurseForge(gameVersion, Constants.CURSEFORGE_MODS_SECTION_ID, query, page,
+                modLoaderTypes, sort, categoryIdParam);
+    }
+
     public static List<CurseForgeProject> searchModsForNeoForge(String gameVersion, String query, int page, String sort,
             String categoryId) {
         Integer categoryIdParam = categoryId == null ? null : Integer.parseInt(categoryId);
 
-        List<Integer> modLoaderTypes = new ArrayList<>();
-        modLoaderTypes.add(Constants.CURSEFORGE_NEOFORGE_MODLOADER_ID);
+        List<Integer> modLoaderTypes = Arrays.asList(Constants.CURSEFORGE_FORGE_MODLOADER_ID);
+
+        List<String> neoForgeForgeCompatabilityVersions = ConfigManager
+                .getConfigItem("loaders.neoforge.forgeCompatibleMinecraftVersions", new ArrayList<String>());
+        if (neoForgeForgeCompatabilityVersions.contains(gameVersion)) {
+            modLoaderTypes.add(Constants.CURSEFORGE_FORGE_MODLOADER_ID);
+        }
+
+        return searchCurseForge(gameVersion, Constants.CURSEFORGE_MODS_SECTION_ID, query, page,
+                modLoaderTypes, sort, categoryIdParam);
+    }
+
+    public static List<CurseForgeProject> searchModsForNeoForgeOrFabric(String gameVersion, String query, int page,
+            String sort,
+            String categoryId) {
+        Integer categoryIdParam = categoryId == null ? null : Integer.parseInt(categoryId);
+
+        List<Integer> modLoaderTypes = Arrays.asList(Constants.CURSEFORGE_FORGE_MODLOADER_ID,
+                Constants.CURSEFORGE_FABRIC_MODLOADER_ID);
 
         List<String> neoForgeForgeCompatabilityVersions = ConfigManager
                 .getConfigItem("loaders.neoforge.forgeCompatibleMinecraftVersions", new ArrayList<String>());

--- a/src/main/java/com/atlauncher/utils/ModrinthApi.java
+++ b/src/main/java/com/atlauncher/utils/ModrinthApi.java
@@ -129,6 +129,15 @@ public class ModrinthApi {
                 ModrinthProjectType.MOD);
     }
 
+    public static ModrinthSearchResult searchModsForForgeOrFabric(List<String> gameVersions, String query, int page,
+            String sort, String category) {
+        List<List<String>> categories = category == null ? Arrays.asList(Arrays.asList("forge", "fabric"))
+                : Arrays.asList(Arrays.asList(category), Arrays.asList("forge", "fabric"));
+
+        return searchModrinth(gameVersions, query, page, sort, categories,
+                ModrinthProjectType.MOD);
+    }
+
     public static ModrinthSearchResult searchModsForNeoForge(List<String> gameVersions, String query, int page,
             String sort, String category) {
         List<List<String>> categories = new ArrayList<>();
@@ -143,6 +152,25 @@ public class ModrinthApi {
             categories.add(Arrays.asList("neoforge", "forge"));
         } else {
             categories.add(Arrays.asList("neoforge"));
+        }
+
+        return searchModrinth(gameVersions, query, page, sort, categories, ModrinthProjectType.MOD);
+    }
+
+    public static ModrinthSearchResult searchModsForNeoForgeOrFabric(List<String> gameVersions, String query, int page,
+            String sort, String category) {
+        List<List<String>> categories = new ArrayList<>();
+
+        if (category != null) {
+            categories.add(Arrays.asList(category));
+        }
+
+        List<String> neoForgeForgeCompatabilityVersions = ConfigManager
+                .getConfigItem("loaders.neoforge.forgeCompatibleMinecraftVersions", new ArrayList<String>());
+        if (gameVersions.stream().anyMatch(gv -> neoForgeForgeCompatabilityVersions.contains(gv))) {
+            categories.add(Arrays.asList("neoforge", "forge", "fabric"));
+        } else {
+            categories.add(Arrays.asList("neoforge", "fabric"));
         }
 
         return searchModrinth(gameVersions, query, page, sort, categories, ModrinthProjectType.MOD);


### PR DESCRIPTION
### Description of the Change

Allows installing Fabric mods when using Forge/NeoForge and have Sinytra Connector installed. Heavily requested.

### Testing

Only manually tested, working fine on latest supported Forge and NeoForge versions for Sinytra Connector

### Related Issues

#942 
