### PR TITLE
fix: [#943] issue with the order of mods in the Edit Mods dialog being wrong

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This changelog only contains the changes that are unreleased. For changes for in
 - Issue installing Modrinth pack with invalid filename [#923]
 - Issue with launching servers with a space in the name not removing Java path correctly on Windows
 - Remove warnings on too much memory being allocated
+- Issue with the order of mods in the Edit Mods dialog being wrong [#943]
 
 ### Misc
 - Speed up CreatePackTab [#933]

--- a/src/main/java/com/atlauncher/gui/dialogs/EditModsDialog.java
+++ b/src/main/java/com/atlauncher/gui/dialogs/EditModsDialog.java
@@ -323,7 +323,7 @@ public class EditModsDialog extends JDialog {
     private void loadMods() {
         List<DisableableMod> mods = instance.launcher.mods.stream().filter(DisableableMod::wasSelected)
                 .filter(m -> !m.skipped && m.type != com.atlauncher.data.Type.worlds)
-                .sorted(Comparator.comparing(m -> m.name)).collect(Collectors.toList());
+                .sorted(Comparator.comparing(m -> m.name, String.CASE_INSENSITIVE_ORDER)).collect(Collectors.toList());
         enabledMods = new ArrayList<>();
         disabledMods = new ArrayList<>();
         int dCount = 0;


### PR DESCRIPTION
### Description of the Change

Fixes edit mods dialog sorting case sensitively

### Testing

![image](https://github.com/user-attachments/assets/686f2e42-1bef-4d21-b135-60303aab8fbe)

### Related Issues

#943 
