### PR TITLE
UI revamped

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,7 @@
     "[po]": {
         "files.trimTrailingWhitespace": true,
         "files.insertFinalNewline": false,
-        "files.trimFinalNewlines": true,
+        "files.trimFinalNewlines": true
     },
     "[java]": {
         "editor.codeActionsOnSave": {
@@ -22,15 +22,30 @@
         }
     ],
     "editor.wordWrapColumn": 120,
-    "editor.rulers": [
-        120
-    ],
+    "editor.rulers": [120],
     "java.import.gradle.wrapper.enabled": true,
-    "java.completion.filteredTypes": [
-        "java.awt.List",
-        "com.sun.*"
-    ],
+    "java.completion.filteredTypes": ["java.awt.List", "com.sun.*"],
     "java.codeGeneration.generateComments": true,
     "git.inputValidationLength": 100,
     "java.compile.nullAnalysis.mode": "automatic",
+    "workbench.colorCustomizations": {
+        "activityBar.activeBackground": "#65c89b",
+        "activityBar.background": "#65c89b",
+        "activityBar.foreground": "#15202b",
+        "activityBar.inactiveForeground": "#15202b99",
+        "activityBarBadge.background": "#945bc4",
+        "activityBarBadge.foreground": "#e7e7e7",
+        "commandCenter.border": "#15202b99",
+        "sash.hoverBorder": "#65c89b",
+        "statusBar.background": "#42b883",
+        "statusBar.foreground": "#15202b",
+        "statusBarItem.hoverBackground": "#359268",
+        "statusBarItem.remoteBackground": "#42b883",
+        "statusBarItem.remoteForeground": "#15202b",
+        "titleBar.activeBackground": "#42b883",
+        "titleBar.activeForeground": "#15202b",
+        "titleBar.inactiveBackground": "#42b88399",
+        "titleBar.inactiveForeground": "#15202b99"
+    },
+    "peacock.color": "#42b883"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,7 @@
     "[po]": {
         "files.trimTrailingWhitespace": true,
         "files.insertFinalNewline": false,
-        "files.trimFinalNewlines": true
+        "files.trimFinalNewlines": true,
     },
     "[java]": {
         "editor.codeActionsOnSave": {
@@ -12,7 +12,7 @@
     "[github-actions-workflow]": {
         "editor.tabSize": 2
     },
-    // "editor.formatOnSave": true,
+    "editor.formatOnSave": true,
     "better-comments.tags": [
         {
             "tag": "#.",
@@ -22,30 +22,15 @@
         }
     ],
     "editor.wordWrapColumn": 120,
-    "editor.rulers": [120],
+    "editor.rulers": [
+        120
+    ],
     "java.import.gradle.wrapper.enabled": true,
-    "java.completion.filteredTypes": ["java.awt.List", "com.sun.*"],
+    "java.completion.filteredTypes": [
+        "java.awt.List",
+        "com.sun.*"
+    ],
     "java.codeGeneration.generateComments": true,
     "git.inputValidationLength": 100,
     "java.compile.nullAnalysis.mode": "automatic",
-    "workbench.colorCustomizations": {
-        "activityBar.activeBackground": "#65c89b",
-        "activityBar.background": "#65c89b",
-        "activityBar.foreground": "#15202b",
-        "activityBar.inactiveForeground": "#15202b99",
-        "activityBarBadge.background": "#945bc4",
-        "activityBarBadge.foreground": "#e7e7e7",
-        "commandCenter.border": "#15202b99",
-        "sash.hoverBorder": "#65c89b",
-        "statusBar.background": "#42b883",
-        "statusBar.foreground": "#15202b",
-        "statusBarItem.hoverBackground": "#359268",
-        "statusBarItem.remoteBackground": "#42b883",
-        "statusBarItem.remoteForeground": "#15202b",
-        "titleBar.activeBackground": "#42b883",
-        "titleBar.activeForeground": "#15202b",
-        "titleBar.inactiveBackground": "#42b88399",
-        "titleBar.inactiveForeground": "#15202b99"
-    },
-    "peacock.color": "#42b883"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,7 +12,7 @@
     "[github-actions-workflow]": {
         "editor.tabSize": 2
     },
-    "editor.formatOnSave": true,
+    // "editor.formatOnSave": true,
     "better-comments.tags": [
         {
             "tag": "#.",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,29 +3,41 @@
 This changelog only contains the changes that are unreleased. For changes for individual releases, please visit the
 [releases](https://github.com/ATLauncher/ATLauncher/releases) page on GitHub.
 
-## 3.4.38.0
+## 3.4.39.0
 
 ### New Features
 - Add AboutTab [#568]
 - Add version option for CLI [#915]
-- Dynaimc fetching of JRE information from nodecdn [#958]
+- Removed Discord RPC
+- Mojang Account support completely removed [#907]
+- Dedicated GPU support for Linux [#986]
+- Add option to open instance.json file for an instance
+- Add checking of Java install location setting before saving
+- Add checking of custom downloads path setting before saving
+- Add image to login with Microsoft account rather than just text
+- Add option to specify a custom backups path
+- Added Tokyonight theme
+- Censor IP addresses from Minecraft in launcher logs [#964]
 
 ### Fixes
-- Java parameters field not being scrollable
+- Invalid Java install location causing issues starting the launcher
+- Fix invalid custom downloads path not being validated on boot
+- Use a scrollpane for the Java Parameter fields [#963]
+- The Java Parameter fields no longer accept new line characters [#666]
+- Issue with NeoForge reinstalls having disabled fields [#955]
+- Issue with the name field missing when reinstalling an instance to a different Minecraft version
+- LegacyJavaFixer not being installed on 1.7.2 Forge
 
 ### Misc
-- Update gradle wrapper version from 8.2 to 8.9 [#886]
-- Migrate to the new Gradle version catalogs for libraries and plugins
+- Update gradle wrapper version from 8.2 to 8.12
 - Update the `application.yml` GitHub workflow [#889]
-- Migrate to Gradle KTS [#898]
 - Refactor News stack
 - Implement HierarchyPanel in AccountsTab [#838]
 - Implement HierarchyPanel in ServersTab [#839]
 - Implement HierarchyPanel in ToolsTab [#840]
-- Mojang Account support completely removed [#907]
+- Implement HierarchyPanel to CreatePackTab [#816]
 - Update versions of Java tested in GitHub workflows
-- Update dependencies
 - Recreate UI on re-localization [#912]
 - Squash a ton of warnings [#918]
 - Implement architecture for all settings tabs [#910]
-- Implement HierarchyPanel to CreatePackTab [#816]
+- Auto update bundled JRE on boot if already installed

--- a/src/main/java/com/atlauncher/constants/UIConstants.java
+++ b/src/main/java/com/atlauncher/constants/UIConstants.java
@@ -52,6 +52,10 @@ public class UIConstants {
     public static final int LAUNCHER_SETTINGS_TAB = 7;
     public static final int LAUNCHER_ABOUT_TAB = 8;
 
+    // design layout options
+    public static final int LAYOUT_DEFAULT = 0;
+    public static final int LAYOUT_GRID = 1;
+
     public static final String getInitialTabName(int initialTab) {
         switch (initialTab) {
             case UIConstants.LAUNCHER_NEWS_TAB:

--- a/src/main/java/com/atlauncher/data/Settings.java
+++ b/src/main/java/com/atlauncher/data/Settings.java
@@ -84,7 +84,7 @@ public class Settings {
     public boolean useRecycleBin = true;
     public boolean enableArmSupport = true;
     public boolean scanModsOnLaunch = true;
-    public boolean enableNewDesginLayout = false; // false = default instance layout, true = new design layout
+    public int selectDesignLayout = 0; // 0 = default instance layout, 1 = new design layout ... more if added
 
     // Mods
     public ModPlatform defaultModPlatform = ModPlatform.CURSEFORGE;

--- a/src/main/java/com/atlauncher/data/Settings.java
+++ b/src/main/java/com/atlauncher/data/Settings.java
@@ -84,6 +84,7 @@ public class Settings {
     public boolean useRecycleBin = true;
     public boolean enableArmSupport = true;
     public boolean scanModsOnLaunch = true;
+    public boolean enableNewDesginLayout = false; // false = default instance layout, true = new design layout
 
     // Mods
     public ModPlatform defaultModPlatform = ModPlatform.CURSEFORGE;
@@ -285,6 +286,11 @@ public class Settings {
         String importedAnalyticsClientId = properties.getProperty("analyticsclientid");
         if (importedAnalyticsClientId != null) {
             analyticsClientId = importedAnalyticsClientId;
+        }
+
+        String importedEnableNewLayout = properties.getProperty("enablenewlayout");
+        if (importedEnableNewLayout != null) {
+            enableConsole = Boolean.parseBoolean(importedEnableNewLayout);
         }
 
         // validate everything
@@ -533,7 +539,7 @@ public class Settings {
 
     public void save() {
         try (OutputStreamWriter fileWriter = new OutputStreamWriter(
-            Files.newOutputStream(FileSystem.SETTINGS), StandardCharsets.UTF_8)) {
+                Files.newOutputStream(FileSystem.SETTINGS), StandardCharsets.UTF_8)) {
             Gsons.DEFAULT.toJson(this, fileWriter);
         } catch (IOException e) {
             LogManager.logStackTrace("Error saving settings", e);

--- a/src/main/java/com/atlauncher/gui/card/NewDesignInstanceCard.java
+++ b/src/main/java/com/atlauncher/gui/card/NewDesignInstanceCard.java
@@ -1,0 +1,611 @@
+/*
+ * ATLauncher - https://github.com/ATLauncher/ATLauncher
+ * Copyright (C) 2013-2022 ATLauncher
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.atlauncher.gui.card;
+
+import java.awt.Dimension;
+import java.awt.GridLayout;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.swing.Box;
+import javax.swing.BoxLayout;
+import javax.swing.JMenuItem;
+import javax.swing.JPanel;
+import javax.swing.JPopupMenu;
+import javax.swing.JScrollPane;
+import javax.swing.JSplitPane;
+import javax.swing.JTextArea;
+import javax.swing.border.EmptyBorder;
+
+import org.mini2Dx.gettext.GetText;
+
+import com.atlauncher.App;
+import com.atlauncher.builders.HTMLBuilder;
+import com.atlauncher.constants.Constants;
+import com.atlauncher.data.BackupMode;
+import com.atlauncher.data.Instance;
+import com.atlauncher.data.minecraft.loaders.LoaderType;
+import com.atlauncher.data.minecraft.loaders.LoaderVersion;
+import com.atlauncher.evnt.listener.RelocalizationListener;
+import com.atlauncher.evnt.manager.RelocalizationManager;
+import com.atlauncher.gui.components.DropDownButton;
+import com.atlauncher.gui.components.NewDesginImagePanel;
+import com.atlauncher.gui.components.NewDesginPanel;
+import com.atlauncher.gui.dialogs.AddModsDialog;
+import com.atlauncher.gui.dialogs.EditModsDialog;
+import com.atlauncher.gui.dialogs.InstanceExportDialog;
+import com.atlauncher.gui.dialogs.InstanceSettingsDialog;
+import com.atlauncher.gui.dialogs.ProgressDialog;
+import com.atlauncher.managers.AccountManager;
+import com.atlauncher.managers.ConfigManager;
+import com.atlauncher.managers.DialogManager;
+import com.atlauncher.managers.InstanceManager;
+import com.atlauncher.network.Analytics;
+import com.atlauncher.network.analytics.AnalyticsEvent;
+import com.atlauncher.utils.OS;
+
+/**
+ * <p/>
+ * Class for displaying instances in the Instance Tab
+ */
+@SuppressWarnings("serial")
+public class NewDesignInstanceCard extends NewDesginPanel implements RelocalizationListener {
+
+    private final Instance instance;
+    private final JTextArea descArea = new JTextArea();
+    private final NewDesginImagePanel image;
+
+    private final JPopupMenu playPopupMenu = new JPopupMenu();
+    private final JMenuItem playOnlinePlayMenuItem = new JMenuItem(GetText.tr("Play Online"));
+    private final JMenuItem playOfflinePlayMenuItem = new JMenuItem(GetText.tr("Play Offline"));
+    private final DropDownButton playButton = new DropDownButton(GetText.tr("Play"), playPopupMenu, true,
+            new MouseAdapter() {
+                @Override
+                public void mousePressed(MouseEvent e) {
+                    play(false);
+                }
+            });
+
+    private final JPopupMenu settingsPopupMenu = new JPopupMenu();
+    private final JMenuItem exportItem = new JMenuItem(GetText.tr("Export"));
+    private final JMenuItem normalBackupMenuItem = new JMenuItem(GetText.tr("Normal Backup"));
+    private final JMenuItem normalPlusModsBackupMenuItem = new JMenuItem(GetText.tr("Normal + Mods Backup"));
+    private final JMenuItem fullBackupMenuItem = new JMenuItem(GetText.tr("Full Backup"));
+    private final DropDownButton settingsButton = new DropDownButton(GetText.tr("Settings"), settingsPopupMenu, true,
+            new MouseAdapter() {
+                @Override
+                public void mousePressed(MouseEvent e) {
+                    Analytics.trackEvent(AnalyticsEvent.forInstanceEvent("instance_settings", instance));
+                    new InstanceSettingsDialog(instance);
+                }
+            });
+
+    private final JPopupMenu moddingPopupMenu = new JPopupMenu();
+    private final JMenuItem addModsItem = new JMenuItem(GetText.tr("Add Mods"));
+    private final JMenuItem editModsItem = new JMenuItem(GetText.tr("Edit Mods"));
+    private final DropDownButton moddingButton = new DropDownButton(GetText.tr("Modding"), moddingPopupMenu);
+
+    private final JPopupMenu morePopupMenu = new JPopupMenu();
+    private final JMenuItem openFolderItem = new JMenuItem(GetText.tr("Open Folder"));
+    private final JMenuItem openResourceMenuItem = new JMenuItem(GetText.tr("Open Resources"));
+    private final JMenuItem discordLinkMenuItem = new JMenuItem(GetText.tr("Discord"));
+    private final JMenuItem supportLinkMenuItem = new JMenuItem(GetText.tr("Support"));
+    private final JMenuItem websiteLinkMenuItem = new JMenuItem(GetText.tr("Website"));
+    private final JMenuItem wikiLinkMenuItem = new JMenuItem(GetText.tr("Wiki"));
+    private final JMenuItem sourceLinkMenuItem = new JMenuItem(GetText.tr("Source"));
+    private final JMenuItem updateItem = new JMenuItem(GetText.tr("Update"));
+    private final JMenuItem serversItem = new JMenuItem(GetText.tr("Servers"));
+    private final JMenuItem websiteItem = new JMenuItem(GetText.tr("Open Website"));
+    private final DropDownButton moreButton = new DropDownButton("...", morePopupMenu);
+
+    private final JPopupMenu editInstancePopupMenu = new JPopupMenu();
+    private final JMenuItem reinstallMenuItem = new JMenuItem(GetText.tr("Reinstall"));
+    private final JMenuItem cloneMenuItem = new JMenuItem(GetText.tr("Clone"));
+    private final JMenuItem renameMenuItem = new JMenuItem(GetText.tr("Rename"));
+    private final JMenuItem changeDescriptionMenuItem = new JMenuItem(GetText.tr("Change Description"));
+    private final JMenuItem changeImageMenuItem = new JMenuItem(GetText.tr("Change Image"));
+    private final JMenuItem deleteInstanceItem = new JMenuItem(GetText.tr("Delete"));
+
+    // #. {0} is the loader (Forge/Fabric/Quilt)
+    private final JMenuItem addFabricMenuItem = new JMenuItem(GetText.tr("Add {0}", "Fabric"));
+    // #. {0} is the loader (Forge/Fabric/Quilt)
+    private final JMenuItem changeFabricVersionMenuItem = new JMenuItem(GetText.tr("Change {0} Version", "Fabric"));
+    // #. {0} is the loader (Forge/Fabric/Quilt)
+    private final JMenuItem removeFabricMenuItem = new JMenuItem(GetText.tr("Remove {0}", "Fabric"));
+    // #. {0} is the loader (Forge/Fabric/Quilt)
+    private final JMenuItem addForgeMenuItem = new JMenuItem(GetText.tr("Add {0}", "Forge"));
+    // #. {0} is the loader (Forge/Fabric/Quilt)
+    private final JMenuItem changeForgeVersionMenuItem = new JMenuItem(GetText.tr("Change {0} Version", "Forge"));
+    // #. {0} is the loader (Forge/Fabric/Quilt)
+    private final JMenuItem removeForgeMenuItem = new JMenuItem(GetText.tr("Remove {0}", "Forge"));
+    // #. {0} is the loader (Forge/Fabric/Quilt)
+    private final JMenuItem addLegacyFabricMenuItem = new JMenuItem(GetText.tr("Add {0}", "Legacy Fabric"));
+    // #. {0} is the loader (Forge/LegacyFabric/Quilt)
+    private final JMenuItem changeLegacyFabricVersionMenuItem = new JMenuItem(
+            GetText.tr("Change {0} Version", "Legacy Fabric"));
+    // #. {0} is the loader (Forge/LegacyFabric/Quilt)
+    private final JMenuItem removeLegacyFabricMenuItem = new JMenuItem(GetText.tr("Remove {0}", "Legacy Fabric"));
+    // #. {0} is the loader (Forge/Fabric/Quilt)
+    private final JMenuItem addNeoForgeMenuItem = new JMenuItem(GetText.tr("Add {0}", "NeoForge"));
+    // #. {0} is the loader (Forge/Fabric/Quilt)
+    private final JMenuItem changeNeoForgeVersionMenuItem = new JMenuItem(GetText.tr("Change {0} Version", "NeoForge"));
+    // #. {0} is the loader (Forge/Fabric/Quilt)
+    private final JMenuItem removeNeoForgeMenuItem = new JMenuItem(GetText.tr("Remove {0}", "NeoForge"));
+    // #. {0} is the loader (Forge/Fabric/Quilt)
+    private final JMenuItem addQuiltMenuItem = new JMenuItem(GetText.tr("Add {0}", "Quilt"));
+    // #. {0} is the loader (Forge/Fabric/Quilt)
+    private final JMenuItem changeQuiltVersionMenuItem = new JMenuItem(GetText.tr("Change {0} Version", "Quilt"));
+    // #. {0} is the loader (Forge/Fabric/Quilt)
+    private final JMenuItem removeQuiltMenuItem = new JMenuItem(GetText.tr("Remove {0}", "Quilt"));
+    private final DropDownButton editInstanceButton = new DropDownButton(GetText.tr("Edit Instance"),
+            editInstancePopupMenu);
+
+    private final boolean hasUpdate;
+
+    public NewDesignInstanceCard(Instance instance, boolean hasUpdate, String instanceTitleFormat) {
+        super(instance, instanceTitleFormat);
+
+        this.instance = instance;
+        this.image = new NewDesginImagePanel(() -> instance.getImage().getImage());
+        this.hasUpdate = hasUpdate;
+
+        setupDescription();
+        setupPlayPopupMenus();
+        setupSettingsPopupMenu();
+        setupModingPopupMenu();
+        setupEditInstanceMenu();
+        setupMorePopupMenu();
+
+        // button grid setup block
+        JPanel buttonGrid = new JPanel(new GridLayout(0, 2, 8, 6));
+        buttonGrid.setBorder(new EmptyBorder(2, 10, 2, 10));
+        buttonGrid.add(playButton);
+        buttonGrid.add(moddingButton);
+        buttonGrid.add(settingsButton);
+        buttonGrid.add(editInstanceButton);
+        // button grid setup end block
+
+        // card main forming
+        JScrollPane desc = new JScrollPane(descArea, JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED,
+                JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
+        desc.setPreferredSize(new Dimension(getPreferredSize().width, 32));
+
+        JPanel upper = new JPanel();
+        upper.setLayout(new BoxLayout(upper, BoxLayout.Y_AXIS));
+
+        JSplitPane headerSplitter = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, mainTitile, moreButton);
+        headerSplitter.setResizeWeight(.85);
+        upper.add(headerSplitter);
+        upper.add(Box.createHorizontalGlue());
+        upper.add(desc);
+
+        JSplitPane subSplitter = new JSplitPane(JSplitPane.VERTICAL_SPLIT, upper, buttonGrid);
+        subSplitter.setEnabled(false);
+
+        JSplitPane mainSpitter = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, image, subSplitter);
+        mainSpitter.setEnabled(false);
+
+        add(mainSpitter);
+
+        RelocalizationManager.addListener(this);
+
+    }
+
+    private void setupPlayPopupMenus() {
+        playOnlinePlayMenuItem.addActionListener(e -> {
+            play(false);
+        });
+        playPopupMenu.add(playOnlinePlayMenuItem);
+
+        playOfflinePlayMenuItem.addActionListener(e -> {
+            play(true);
+        });
+        playPopupMenu.add(playOfflinePlayMenuItem);
+    }
+
+    private void setupSettingsPopupMenu() {
+        // export block
+        exportItem.addActionListener(e -> {
+            Analytics.trackEvent(AnalyticsEvent.forInstanceEvent("instance_export", instance));
+            new InstanceExportDialog(instance);
+        });
+        settingsPopupMenu.add(exportItem);
+        exportItem.setEnabled(instance.canBeExported());
+        // export end block
+
+        settingsPopupMenu.addSeparator();
+        // backup block
+        normalBackupMenuItem.addActionListener(e -> instance.backup(BackupMode.NORMAL));
+        settingsPopupMenu.add(normalBackupMenuItem);
+
+        normalPlusModsBackupMenuItem.addActionListener(e -> instance.backup(BackupMode.NORMAL_PLUS_MODS));
+        settingsPopupMenu.add(normalPlusModsBackupMenuItem);
+
+        fullBackupMenuItem.addActionListener(e -> instance.backup(BackupMode.FULL));
+        settingsPopupMenu.add(fullBackupMenuItem);
+        // backup end block
+
+    }
+
+    private void setupModingPopupMenu() {
+        // add mods block
+        addModsItem.addActionListener(e -> {
+            Analytics.trackEvent(AnalyticsEvent.forInstanceEvent("instance_add_mods", instance));
+            new AddModsDialog(instance);
+            exportItem.setEnabled(instance.canBeExported());
+        });
+        moddingPopupMenu.add(addModsItem);
+        addModsItem.setEnabled(false);
+        if (instance.launcher.enableCurseForgeIntegration
+                && (ConfigManager.getConfigItem("platforms.curseforge.modsEnabled", true) == true
+                        || (ConfigManager.getConfigItem("platforms.modrinth.modsEnabled", true) == true
+                                && this.instance.launcher.loaderVersion != null))) {
+            addModsItem.setEnabled(true);
+        }
+        // add mods end block
+
+        // edit mod block
+        editModsItem.addActionListener(e -> {
+            Analytics.trackEvent(AnalyticsEvent.forInstanceEvent("instance_edit_mods", instance));
+            new EditModsDialog(instance);
+            exportItem.setEnabled(instance.canBeExported());
+        });
+        moddingPopupMenu.add(editModsItem);
+        editModsItem.setEnabled(false);
+        if (instance.launcher.enableEditingMods) {
+            editModsItem.setEnabled(true);
+        }
+        // edit mod end block
+    }
+
+    private void setupMorePopupMenu() {
+        moreButton.setBackground(null);
+        moreButton.setBorder(new EmptyBorder(1, 1, 1, 1));
+
+        // open folder block
+        openFolderItem.addActionListener(e -> OS.openFileExplorer(instance.getRoot()));
+        morePopupMenu.add(openFolderItem);
+
+        openResourceMenuItem.addActionListener(e -> {
+            DialogManager.okDialog().setTitle(GetText.tr("Reminder"))
+                    .setContent(GetText.tr("You may not distribute ANY resources."))
+                    .setType(DialogManager.WARNING).show();
+            OS.openFileExplorer(instance.getMinecraftJarLibraryPath());
+        });
+        morePopupMenu.add(openResourceMenuItem);
+        // open folder end block
+
+        morePopupMenu.addSeparator();
+
+        // update block
+        updateItem.addActionListener(e -> {
+            if (AccountManager.getSelectedAccount() == null) {
+                DialogManager.okDialog().setTitle(GetText.tr("No Account Selected"))
+                        .setContent(GetText.tr("Cannot update pack as you have no account selected."))
+                        .setType(DialogManager.ERROR).show();
+                return;
+            }
+
+            Analytics.trackEvent(AnalyticsEvent.forInstanceEvent("instance_update", instance));
+            instance.update();
+        });
+        morePopupMenu.add(updateItem);
+        if (!instance.isUpdatable()) {
+            updateItem.setEnabled(instance.isUpdatable());
+        }
+        if (!hasUpdate) {
+            updateItem.setEnabled(false);
+        }
+        // update end block
+
+        // server item block
+        serversItem.addActionListener(e -> OS.openWebBrowser(
+                String.format("%s/%s?utm_source=launcher&utm_medium=button&utm_campaign=instance_v2_button",
+                        Constants.SERVERS_LIST_PACK, instance.getSafePackName())));
+        morePopupMenu.add(serversItem);
+        if (instance.isExternalPack() || instance.launcher.vanillaInstance) {
+            serversItem.setEnabled(false);
+        }
+
+        if (instance.getPack() != null && instance.getPack().system) {
+            serversItem.setEnabled(false);
+        }
+        // server end block
+
+        // website block
+        websiteItem.addActionListener(e -> OS.openWebBrowser(instance.getWebsiteUrl()));
+        morePopupMenu.add(websiteItem);
+        websiteItem.setEnabled(instance.hasWebsite());
+        // website end block
+
+        // extra buttons in more popup menu
+        if (instance.showGetHelpButton()) {
+            morePopupMenu.addSeparator();
+            if (instance.getDiscordInviteUrl() != null) {
+                discordLinkMenuItem.addActionListener(e -> OS.openWebBrowser(instance.getDiscordInviteUrl()));
+                morePopupMenu.add(discordLinkMenuItem);
+            }
+
+            if (instance.getSupportUrl() != null) {
+                supportLinkMenuItem.addActionListener(e -> OS.openWebBrowser(instance.getSupportUrl()));
+                morePopupMenu.add(supportLinkMenuItem);
+            }
+
+            if (instance.getWebsiteUrl() != null) {
+                websiteLinkMenuItem.addActionListener(e -> OS.openWebBrowser(instance.getWebsiteUrl()));
+                morePopupMenu.add(websiteLinkMenuItem);
+            }
+
+            if (instance.getWikiUrl() != null) {
+                wikiLinkMenuItem.addActionListener(e -> OS.openWebBrowser(instance.getWikiUrl()));
+                morePopupMenu.add(wikiLinkMenuItem);
+            }
+
+            if (instance.getSourceUrl() != null) {
+                sourceLinkMenuItem.addActionListener(e -> OS.openWebBrowser(instance.getSourceUrl()));
+                morePopupMenu.add(sourceLinkMenuItem);
+            }
+        }
+
+    }
+
+    void addLoaderItem(String key, JMenuItem add, JMenuItem change, JMenuItem remove, boolean enabled) {
+        if (ConfigManager.getConfigItem("loaders." + key + "enabled", true) == enabled
+                && !ConfigManager
+                        .getConfigItem("loaders." + key + ".disabledMinecraftVersions", new ArrayList<String>())
+                        .contains(instance.id)) {
+            editInstancePopupMenu.add(add);
+            editInstancePopupMenu.add(change);
+        }
+        editInstancePopupMenu.add(remove);
+    }
+
+    private void setupEditInstanceMenu() {
+
+        reinstallMenuItem.addActionListener(e -> instance.startReinstall());
+        editInstancePopupMenu.add(reinstallMenuItem);
+
+        cloneMenuItem.addActionListener(e -> instance.startClone());
+        editInstancePopupMenu.add(cloneMenuItem);
+
+        renameMenuItem.addActionListener(e -> instance.startRename());
+        editInstancePopupMenu.add(renameMenuItem);
+
+        changeDescriptionMenuItem.addActionListener(e -> {
+            instance.startChangeDescription();
+            descArea.setText(instance.launcher.description);
+        });
+
+        editInstancePopupMenu.add(changeDescriptionMenuItem);
+        changeImageMenuItem.addActionListener(e -> {
+            instance.startChangeImage();
+            image.setImage(instance.getImage().getImage());
+        });
+        editInstancePopupMenu.add(changeImageMenuItem);
+
+        deleteInstanceItem.addActionListener(e -> {
+            int ret = DialogManager.yesNoDialog(false).setTitle(GetText.tr("Delete Instance"))
+                    .setContent(
+                            GetText.tr("Are you sure you want to delete the instance \"{0}\"?", instance.launcher.name))
+                    .setType(DialogManager.ERROR).show();
+
+            if (ret == DialogManager.YES_OPTION) {
+                Analytics.trackEvent(AnalyticsEvent.forInstanceEvent("instance_delete", instance));
+                final ProgressDialog dialog = new ProgressDialog(GetText.tr("Deleting Instance"), 0,
+                        GetText.tr("Deleting Instance. Please wait..."), null, App.launcher.getParent());
+                dialog.addThread(new Thread(() -> {
+                    InstanceManager.removeInstance(instance);
+                    dialog.close();
+                    App.TOASTER.pop(GetText.tr("Deleted Instance Successfully"));
+                }));
+                dialog.start();
+            }
+        });
+        editInstancePopupMenu.add(deleteInstanceItem);
+
+        editInstancePopupMenu.addSeparator();
+
+        addLoaderItem("fabric", addFabricMenuItem, changeFabricVersionMenuItem, removeFabricMenuItem, true);
+        addLoaderItem("forge", addForgeMenuItem, changeForgeVersionMenuItem, removeForgeMenuItem, true);
+        addLoaderItem("legacyfabric", addLegacyFabricMenuItem, changeLegacyFabricVersionMenuItem,
+                removeLegacyFabricMenuItem, true);
+        addLoaderItem("neoforge", addNeoForgeMenuItem, changeNeoForgeVersionMenuItem, removeNeoForgeMenuItem, true);
+        addLoaderItem("quilt", addQuiltMenuItem, changeQuiltVersionMenuItem, removeQuiltMenuItem, false);
+
+        // loader things
+        addFabricMenuItem.addActionListener(e -> {
+            instance.addLoader(LoaderType.FABRIC);
+            setEditInstanceMenuItemVisibility();
+        });
+        addForgeMenuItem.addActionListener(e -> {
+            instance.addLoader(LoaderType.FORGE);
+            setEditInstanceMenuItemVisibility();
+        });
+        addLegacyFabricMenuItem.addActionListener(e -> {
+            instance.addLoader(LoaderType.LEGACY_FABRIC);
+            setEditInstanceMenuItemVisibility();
+        });
+        addNeoForgeMenuItem.addActionListener(e -> {
+            instance.addLoader(LoaderType.NEOFORGE);
+            setEditInstanceMenuItemVisibility();
+        });
+        addQuiltMenuItem.addActionListener(e -> {
+            instance.addLoader(LoaderType.QUILT);
+            setEditInstanceMenuItemVisibility();
+        });
+        List.of(changeFabricVersionMenuItem,
+                changeForgeVersionMenuItem,
+                changeLegacyFabricVersionMenuItem,
+                changeNeoForgeVersionMenuItem,
+                changeQuiltVersionMenuItem)
+                .forEach(item -> {
+                    item.addActionListener(e -> {
+                        instance.changeLoaderVersion();
+                        setEditInstanceMenuItemVisibility();
+                    });
+                });
+        List.of(removeFabricMenuItem,
+                removeForgeMenuItem,
+                removeLegacyFabricMenuItem,
+                removeNeoForgeMenuItem,
+                removeQuiltMenuItem)
+                .forEach(item -> {
+                    item.addActionListener(e -> {
+                        instance.removeLoader();
+                        setEditInstanceMenuItemVisibility();
+                    });
+                });
+        setEditInstanceMenuItemVisibility();
+    }
+
+    private void setEditInstanceMenuItemVisibility() {
+        reinstallMenuItem.setVisible(instance.isUpdatable());
+
+        final boolean loaderVersionIsNull = instance.launcher.loaderVersion == null;
+        final LoaderVersion loaderVersion = instance.launcher.loaderVersion;
+
+        addFabricMenuItem.setVisible(loaderVersionIsNull);
+        addForgeMenuItem.setVisible(loaderVersionIsNull);
+        addLegacyFabricMenuItem.setVisible(loaderVersionIsNull);
+        addNeoForgeMenuItem.setVisible(loaderVersionIsNull);
+        addQuiltMenuItem.setVisible(loaderVersionIsNull);
+
+        changeFabricVersionMenuItem.setVisible(!loaderVersionIsNull && loaderVersion.isFabric());
+        changeForgeVersionMenuItem.setVisible(!loaderVersionIsNull && loaderVersion.isForge());
+        changeLegacyFabricVersionMenuItem.setVisible(!loaderVersionIsNull && loaderVersion.isLegacyFabric());
+        changeNeoForgeVersionMenuItem.setVisible(!loaderVersionIsNull && loaderVersion.isNeoForge());
+        changeQuiltVersionMenuItem.setVisible(!loaderVersionIsNull && loaderVersion.isQuilt());
+
+        removeFabricMenuItem.setVisible(!loaderVersionIsNull && loaderVersion.isFabric());
+        removeForgeMenuItem.setVisible(!loaderVersionIsNull && loaderVersion.isForge());
+        removeLegacyFabricMenuItem.setVisible(!loaderVersionIsNull && loaderVersion.isLegacyFabric());
+        removeNeoForgeMenuItem.setVisible(!loaderVersionIsNull && loaderVersion.isNeoForge());
+        removeQuiltMenuItem.setVisible(!loaderVersionIsNull && loaderVersion.isQuilt());
+    }
+
+    private void setupDescription() {
+        descArea.setText(instance.getPackDescription());
+        descArea.setEditable(false);
+        descArea.setHighlighter(null);
+        descArea.setLineWrap(true);
+        descArea.setWrapStyleWord(true);
+        descArea.setForeground(getBackground().brighter().brighter().brighter().brighter());
+        if (instance.canChangeDescription()) {
+            descArea.addMouseListener(new MouseAdapter() {
+                @Override
+                public void mouseClicked(MouseEvent e) {
+                    if (e.getClickCount() == 2) {
+                        instance.startChangeDescription();
+                        descArea.setText(instance.getPackDescription());
+                    }
+                }
+            });
+        }
+    }
+
+    private void play(boolean offline) {
+        if (!instance.launcher.isPlayable) {
+            DialogManager.okDialog().setTitle(GetText.tr("Instance Corrupt"))
+                    .setContent(GetText
+                            .tr("Cannot play instance as it's corrupted. Please reinstall, update or delete it."))
+                    .setType(DialogManager.ERROR).show();
+            return;
+        }
+
+        if (!App.settings.ignoreJavaOnInstanceLaunch && instance.shouldShowWrongJavaWarning()) {
+            DialogManager.okDialog().setTitle(GetText.tr("Cannot launch instance due to your Java version"))
+                    .setContent(new HTMLBuilder().center().text(GetText.tr(
+                            "There was an issue launching this instance.<br/><br/>This version of the pack requires a Java version which you are not using.<br/><br/>Please install that version of Java and try again.<br/><br/>Java version needed: {0}",
+                            instance.launcher.java.getVersionString())).build())
+                    .setType(DialogManager.ERROR).show();
+            return;
+        }
+
+        if (hasUpdate && !instance.hasLatestUpdateBeenIgnored()) {
+            int ret = DialogManager.yesNoDialog().setTitle(GetText.tr("Update Available"))
+                    .setContent(new HTMLBuilder().center()
+                            .text(GetText.tr(
+                                    "An update is available for this instance.<br/><br/>Do you want to update now?"))
+                            .build())
+                    .addOption(GetText.tr("Ignore This Update"))
+                    .addOption(GetText.tr("Don't Remind Me Again")).setType(DialogManager.INFO)
+                    .show();
+
+            if (ret == 0) {
+                if (AccountManager.getSelectedAccount() == null) {
+                    DialogManager.okDialog().setTitle(GetText.tr("No Account Selected"))
+                            .setContent(GetText.tr("Cannot update pack as you have no account selected."))
+                            .setType(DialogManager.ERROR).show();
+                } else {
+                    Analytics.trackEvent(AnalyticsEvent.forInstanceEvent("instance_update", instance));
+                    instance.update();
+                }
+            } else if (ret == 1 || ret == DialogManager.CLOSED_OPTION || ret == 2 || ret == 3) {
+                if (ret == 2) {
+                    instance.ignoreUpdate();
+                } else if (ret == 3) {
+                    instance.ignoreAllUpdates();
+                }
+
+                if (!App.launcher.minecraftLaunched) {
+                    if (instance.launch()) {
+                        App.launcher.setMinecraftLaunched(true);
+                    }
+                }
+            }
+        } else {
+            if (!App.launcher.minecraftLaunched) {
+                if (instance.launch(offline)) {
+                    App.launcher.setMinecraftLaunched(true);
+                }
+            }
+        }
+    }
+
+    public Instance getInstance() {
+        return instance;
+    }
+
+    @Override
+    public void onRelocalization() {
+        this.playButton.setText(GetText.tr("Play"));
+        this.updateItem.setText(GetText.tr("Update"));
+        this.deleteInstanceItem.setText(GetText.tr("Delete"));
+        this.serversItem.setText(GetText.tr("Servers"));
+        this.websiteItem.setText(GetText.tr("Open Website"));
+        this.openFolderItem.setText(GetText.tr("Open Folder"));
+        this.openResourceMenuItem.setText(GetText.tr("Open Resources"));
+        this.settingsButton.setText(GetText.tr("Settings"));
+
+        this.normalBackupMenuItem.setText(GetText.tr("Normal Backup"));
+        this.normalPlusModsBackupMenuItem.setText(GetText.tr("Normal + Mods Backup"));
+        this.fullBackupMenuItem.setText(GetText.tr("Full Backup"));
+
+        this.moddingButton.setText(GetText.tr("Modding"));
+        this.addModsItem.setText(GetText.tr("Add Mods"));
+        this.editModsItem.setText(GetText.tr("Edit Mods"));
+
+        this.discordLinkMenuItem.setText(GetText.tr("Discord"));
+        this.supportLinkMenuItem.setText(GetText.tr("Support"));
+        this.websiteLinkMenuItem.setText(GetText.tr("Website"));
+        this.wikiLinkMenuItem.setText(GetText.tr("Wiki"));
+        this.sourceLinkMenuItem.setText(GetText.tr("Source"));
+    }
+}

--- a/src/main/java/com/atlauncher/gui/card/NewDesignServerCard.java
+++ b/src/main/java/com/atlauncher/gui/card/NewDesignServerCard.java
@@ -1,0 +1,263 @@
+/*
+ * ATLauncher - https://github.com/ATLauncher/ATLauncher
+ * Copyright (C) 2013-2022 ATLauncher
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.atlauncher.gui.card;
+
+import java.awt.Cursor;
+import java.awt.Dimension;
+import java.awt.GridLayout;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+
+import javax.swing.BorderFactory;
+import javax.swing.BoxLayout;
+import javax.swing.JMenuItem;
+import javax.swing.JPanel;
+import javax.swing.JPopupMenu;
+import javax.swing.JScrollPane;
+import javax.swing.JSplitPane;
+import javax.swing.JTextArea;
+import javax.swing.border.EmptyBorder;
+
+import org.mini2Dx.gettext.GetText;
+
+import com.atlauncher.App;
+import com.atlauncher.data.Server;
+import com.atlauncher.evnt.listener.RelocalizationListener;
+import com.atlauncher.evnt.manager.RelocalizationManager;
+import com.atlauncher.gui.components.DropDownButton;
+import com.atlauncher.gui.components.NewDesginImagePanel;
+import com.atlauncher.gui.components.NewDesginPanel;
+import com.atlauncher.gui.dialogs.ProgressDialog;
+import com.atlauncher.managers.DialogManager;
+import com.atlauncher.managers.ServerManager;
+import com.atlauncher.network.Analytics;
+import com.atlauncher.network.analytics.AnalyticsEvent;
+import com.atlauncher.utils.OS;
+
+@SuppressWarnings("serial")
+public class NewDesignServerCard extends NewDesginPanel implements RelocalizationListener {
+    private final Server server;
+    private final NewDesginImagePanel image;
+
+    private final JPopupMenu launchPopMenu = new JPopupMenu();
+    private final JMenuItem launchAndCloseButton = new JMenuItem(GetText.tr("Launch & Close"));
+    private final JMenuItem launchWithGui = new JMenuItem(GetText.tr("Launch With GUI"));
+    private final JMenuItem launchWithGuiAndClose = new JMenuItem(GetText.tr("Launch With GUI & Close"));
+    private final DropDownButton launchButton = new DropDownButton(GetText.tr("Launch"), launchPopMenu, true,
+            new MouseAdapter() {
+                @Override
+                public void mousePressed(MouseEvent e) {
+                    server.launch("nogui", false);
+                }
+            });
+
+    private final JPopupMenu morePopupMenu = new JPopupMenu();
+    private final JMenuItem backupButton = new JMenuItem(GetText.tr("Backup"));
+    private final JMenuItem deleteButton = new JMenuItem(GetText.tr("Delete"));
+    private final JMenuItem openButton = new JMenuItem(GetText.tr("Open Folder"));
+    // seaprator
+    private final JMenuItem discordLinkMenuItem = new JMenuItem(GetText.tr("Discord"));
+    private final JMenuItem supportLinkMenuItem = new JMenuItem(GetText.tr("Support"));
+    private final JMenuItem websiteLinkMenuItem = new JMenuItem(GetText.tr("Website"));
+    private final JMenuItem wikiLinkMenuItem = new JMenuItem(GetText.tr("Wiki"));
+    private final JMenuItem sourceLinkMenuItem = new JMenuItem(GetText.tr("Source"));
+    private final DropDownButton moreButton = new DropDownButton("More", morePopupMenu);
+
+    private final JTextArea descArea = new JTextArea();
+
+    public NewDesignServerCard(Server server) {
+        super(server);
+        this.server = server;
+        this.image = new NewDesginImagePanel(() -> server.getImage().getImage());
+
+        descArea.setText(server.getPackDescription());
+        descArea.setBorder(BorderFactory.createEmptyBorder(0, 5, 0, 5));
+        descArea.setEditable(false);
+        descArea.setHighlighter(null);
+        descArea.setLineWrap(true);
+        descArea.setWrapStyleWord(true);
+        descArea.setForeground(getBackground().brighter().brighter().brighter().brighter());
+
+        descArea.addMouseListener(new MouseAdapter() {
+            @Override
+            public void mouseClicked(MouseEvent e) {
+                if (e.getClickCount() == 2) {
+                    server.startChangeDescription();
+                    descArea.setText(server.getPackDescription());
+                }
+            }
+        });
+
+        JPanel buttonGrid = new JPanel(new GridLayout(0, 2, 8, 6));
+        buttonGrid.setBorder(new EmptyBorder(10, 10, 10, 10));
+
+        buttonGrid.add(this.launchButton);
+        launchPopMenu.add(this.launchAndCloseButton);
+        launchPopMenu.add(this.launchWithGui);
+        launchPopMenu.add(this.launchWithGuiAndClose);
+
+        morePopupMenu.add(this.openButton);
+        morePopupMenu.add(this.backupButton);
+        morePopupMenu.add(this.deleteButton);
+        buttonGrid.add(moreButton);
+
+        // unfortunately OSX doesn't allow us to pass arguments with open and Terminal
+        if (OS.isMac()) {
+            this.launchButton.setVisible(false);
+            this.launchAndCloseButton.setVisible(false);
+        }
+
+        JScrollPane desc = new JScrollPane(this.descArea, JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED,
+                JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
+        desc.setPreferredSize(new Dimension(getPreferredSize().width, 50));
+
+        add(image);
+        JPanel upper = new JPanel();
+        upper.setLayout(new BoxLayout(upper, BoxLayout.Y_AXIS));
+
+        upper.add(mainTitile);
+        upper.add(desc);
+
+        JSplitPane subSplitter = new JSplitPane(JSplitPane.VERTICAL_SPLIT, upper, buttonGrid);
+        JSplitPane mainSpitter = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, image, subSplitter);
+        mainSpitter.setEnabled(false);
+        subSplitter.setEnabled(false);
+        add(mainSpitter);
+
+        setupButtonPopupMenus();
+
+        RelocalizationManager.addListener(this);
+
+        this.addActionListeners();
+        this.addMouseListeners();
+    }
+
+    private void addActionListeners() {
+        // this.launchButton.addActionListener(e -> );
+        this.launchAndCloseButton.addActionListener(e -> server.launch("nogui", true));
+        this.launchWithGui.addActionListener(e -> server.launch(false));
+        this.launchWithGuiAndClose.addActionListener(e -> server.launch(true));
+        this.backupButton.addActionListener(e -> server.backup());
+        this.deleteButton.addActionListener(e -> {
+            int ret = DialogManager.yesNoDialog(false).setTitle(GetText.tr("Delete Server"))
+                    .setContent(GetText.tr("Are you sure you want to delete this server?")).setType(DialogManager.ERROR)
+                    .show();
+
+            if (ret == DialogManager.YES_OPTION) {
+                Analytics.trackEvent(AnalyticsEvent.forServerEvent("server_delete", server));
+                final ProgressDialog dialog = new ProgressDialog(GetText.tr("Deleting Server"), 0,
+                        GetText.tr("Deleting Server. Please wait..."), null, App.launcher.getParent());
+                dialog.addThread(new Thread(() -> {
+                    ServerManager.removeServer(server);
+                    dialog.close();
+                    App.TOASTER.pop(GetText.tr("Deleted Server Successfully"));
+                }));
+                dialog.start();
+            }
+        });
+        this.openButton.addActionListener(e -> OS.openFileExplorer(server.getRoot()));
+    }
+
+    private void addMouseListeners() {
+        this.image.addMouseListener(new MouseAdapter() {
+            @Override
+            public void mouseClicked(MouseEvent e) {
+                if (e.getButton() == MouseEvent.BUTTON1 && e.getClickCount() >= 2) {
+                    if (OS.isMac()) {
+                        server.launch(false);
+                    } else {
+                        server.launch("nogui", false);
+                    }
+                } else if (e.getButton() == MouseEvent.BUTTON3) {
+                    JPopupMenu rightClickMenu = new JPopupMenu();
+
+                    JMenuItem changeDescriptionItem = new JMenuItem(GetText.tr("Change Description"));
+                    rightClickMenu.add(changeDescriptionItem);
+
+                    JMenuItem changeImageItem = new JMenuItem(GetText.tr("Change Image"));
+                    rightClickMenu.add(changeImageItem);
+
+                    rightClickMenu.show(image, e.getX(), e.getY());
+
+                    changeDescriptionItem.addActionListener(e14 -> {
+                        server.startChangeDescription();
+                        descArea.setText(server.getPackDescription());
+                    });
+
+                    changeImageItem.addActionListener(e13 -> {
+                        server.startChangeImage();
+                        image.setImage(server.getImage().getImage());
+                    });
+                }
+            }
+
+            @Override
+            public void mouseEntered(MouseEvent e) {
+                super.mouseEntered(e);
+                setCursor(new Cursor(Cursor.HAND_CURSOR));
+            }
+
+            @Override
+            public void mouseExited(MouseEvent e) {
+                super.mouseExited(e);
+                setCursor(new Cursor(Cursor.DEFAULT_CURSOR));
+            }
+        });
+    }
+
+    private void setupButtonPopupMenus() {
+        if (server.showGetHelpButton()) {
+            morePopupMenu.addSeparator();
+            if (server.getDiscordInviteUrl() != null) {
+                discordLinkMenuItem.addActionListener(e -> OS.openWebBrowser(server.getDiscordInviteUrl()));
+                morePopupMenu.add(discordLinkMenuItem);
+            }
+
+            if (server.getSupportUrl() != null) {
+                supportLinkMenuItem.addActionListener(e -> OS.openWebBrowser(server.getSupportUrl()));
+                morePopupMenu.add(supportLinkMenuItem);
+            }
+
+            if (server.getWebsiteUrl() != null) {
+                websiteLinkMenuItem.addActionListener(e -> OS.openWebBrowser(server.getWebsiteUrl()));
+                morePopupMenu.add(websiteLinkMenuItem);
+            }
+
+            if (server.getWikiUrl() != null) {
+                wikiLinkMenuItem.addActionListener(e -> OS.openWebBrowser(server.getWikiUrl()));
+                morePopupMenu.add(wikiLinkMenuItem);
+            }
+
+            if (server.getSourceUrl() != null) {
+                sourceLinkMenuItem.addActionListener(e -> OS.openWebBrowser(server.getSourceUrl()));
+                morePopupMenu.add(sourceLinkMenuItem);
+            }
+        }
+    }
+
+    @Override
+    public void onRelocalization() {
+        this.launchButton.setText(GetText.tr("Launch"));
+        this.launchAndCloseButton.setText(GetText.tr("Launch & Close"));
+        this.launchWithGui.setText(GetText.tr("Launch With GUI"));
+        this.launchWithGuiAndClose.setText(GetText.tr("Launch With GUI & Close"));
+        this.backupButton.setText(GetText.tr("Backup"));
+        this.deleteButton.setText(GetText.tr("Delete"));
+        this.openButton.setText(GetText.tr("Open Folder"));
+    }
+}

--- a/src/main/java/com/atlauncher/gui/components/NewDesginImagePanel.java
+++ b/src/main/java/com/atlauncher/gui/components/NewDesginImagePanel.java
@@ -1,0 +1,77 @@
+/*
+ * ATLauncher - https://github.com/ATLauncher/ATLauncher
+ * Copyright (C) 2013-2022 ATLauncher
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.atlauncher.gui.components;
+
+import java.awt.Cursor;
+import java.awt.Dimension;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.Image;
+import java.util.concurrent.Callable;
+
+import javax.annotation.Nonnull;
+import javax.swing.JPanel;
+import javax.swing.SwingUtilities;
+
+import com.atlauncher.managers.LogManager;
+
+public final class NewDesginImagePanel extends JPanel {
+    private static final Cursor HAND = new Cursor(Cursor.HAND_CURSOR);
+    private static final int DEFAULT_WIDTH = 100, DEFAULT_HEIGHT = 100;
+
+    private volatile Image image;
+
+    /**
+     * @param imageToLoad Deferred image loading
+     */
+    public NewDesginImagePanel(@Nonnull Callable<Image> imageToLoad) {
+        this.setCursor(HAND);
+        setPreferredSize(new Dimension(DEFAULT_WIDTH, DEFAULT_HEIGHT));
+        // Launch a separate thread to load the image
+        new Thread(() -> {
+            try {
+                setImage(imageToLoad.call());
+            } catch (Exception e) {
+                LogManager.error(e.getMessage());
+            }
+        }).start();
+    }
+
+    public void setImage(@Nonnull Image img) {
+        this.image = img;
+
+        this.setPreferredSize(new Dimension(DEFAULT_WIDTH, DEFAULT_HEIGHT));
+
+        // Repaint on the event thread
+        SwingUtilities.invokeLater(this::repaint);
+    }
+
+    @Override
+    public void paintComponent(Graphics g) {
+        super.paintComponent(g);
+        if (image != null) {
+            Graphics2D g2 = (Graphics2D) g;
+            // crpp the image if not suqare or 1:1
+            if (image.getWidth(null) != image.getHeight(null)) {
+                g2.drawImage(this.image, 0, 0, 100, 100, 0, 0, 100, image.getHeight(null), null);
+            } else {
+                g2.drawImage(this.image, 0, 0, 100, 100, null);
+            }
+        }
+    }
+}

--- a/src/main/java/com/atlauncher/gui/components/NewDesginPanel.java
+++ b/src/main/java/com/atlauncher/gui/components/NewDesginPanel.java
@@ -1,0 +1,116 @@
+/*
+ * ATLauncher - https://github.com/ATLauncher/ATLauncher
+ * Copyright (C) 2013-2022 ATLauncher
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.atlauncher.gui.components;
+
+import java.awt.Component;
+
+import javax.swing.BorderFactory;
+import javax.swing.BoxLayout;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.UIManager;
+
+import com.atlauncher.App;
+import com.atlauncher.data.Instance;
+import com.atlauncher.data.Server;
+import com.atlauncher.evnt.listener.RelocalizationListener;
+import com.atlauncher.evnt.listener.ThemeListener;
+import com.atlauncher.evnt.manager.RelocalizationManager;
+import com.atlauncher.evnt.manager.ThemeManager;
+
+/**
+ * The user-triggered collapsible panel containing the component (trigger) in
+ * the titled border
+ */
+public class NewDesginPanel extends JPanel implements ThemeListener, RelocalizationListener {
+    public static final long serialVersionUID = -343234;
+
+    public JLabel mainTitile = createTitleLabel();// the arrow
+    Server server = null;
+    Instance instance = null;
+
+    /**
+     * @param instance            Given instance
+     * @param instanceTitleFormat Title format for said instance
+     */
+    public NewDesginPanel(Instance instance, String instanceTitleFormat) {
+        this.instance = instance;
+        String title;
+
+        try {
+            title = String.format(instanceTitleFormat, instance.launcher.name, instance.launcher.pack,
+                    instance.launcher.version, instance.id);
+        } catch (Throwable t) {
+            title = instance.launcher.name;
+        }
+
+        if (instance.launcher.isPlayable) {
+            mainTitile.setText(title.substring(0, 16) + "...");
+            mainTitile.setToolTipText(title);
+            mainTitile.setForeground(UIManager.getColor("CollapsiblePanel.normal"));
+        } else {
+            mainTitile.setText(title.substring(0, 12) + "..." + " - " + "Corrupted)");
+            mainTitile.setToolTipText(title + " - " + "Corrupted)");
+            mainTitile.setForeground(UIManager.getColor("CollapsiblePanel.error"));
+        }
+        commonConstructor();
+
+    }
+
+    public NewDesginPanel(Server server) {
+        this.server = server;
+        mainTitile.setText(server.name.substring(0, 8) + "..." + " (" + server.pack + " " + server.version + ")");
+        mainTitile.setToolTipText(server.name + " (" + server.pack + " " + server.version + ")");
+        mainTitile.setForeground(UIManager.getColor("CollapsiblePanel.normal"));
+        commonConstructor();
+
+    }
+
+    /**
+     * Sets layout, creates the content panel and adds it and the title component to
+     * the container, all constructors have this procedure in common.
+     */
+    private void commonConstructor() {
+        mainTitile.setAlignmentX(Component.LEFT_ALIGNMENT);
+        setLayout(new BoxLayout(this, BoxLayout.X_AXIS));
+        setBorder(BorderFactory.createLineBorder(getBackground().brighter(), 2));
+        ThemeManager.addListener(this);
+        RelocalizationManager.addListener(this);
+    }
+
+    /**
+     * Returns a button with an arrow icon and a collapse/expand action listener.
+     */
+    private JLabel createTitleLabel() {
+        JLabel label = new JLabel();
+        label.setFont(App.THEME.getBoldFont().deriveFont(15f));
+        label.setFocusable(false);
+        return label;
+    }
+
+    @Override
+    public void onThemeChange() {
+        updateUI();
+    }
+
+    @Override
+    public void onRelocalization() {
+        mainTitile.setFont(App.THEME.getBoldFont().deriveFont(15f));
+    }
+
+}

--- a/src/main/java/com/atlauncher/gui/tabs/InstancesTab.java
+++ b/src/main/java/com/atlauncher/gui/tabs/InstancesTab.java
@@ -23,9 +23,11 @@ import javax.swing.JScrollPane;
 
 import org.mini2Dx.gettext.GetText;
 
+import com.atlauncher.App;
 import com.atlauncher.gui.panels.HierarchyPanel;
 import com.atlauncher.gui.tabs.instances.InstancesListPanel;
 import com.atlauncher.gui.tabs.instances.InstancesNavigationPanel;
+import com.atlauncher.gui.tabs.instances.NewDesignInstancesListPanel;
 import com.atlauncher.utils.Utils;
 import com.atlauncher.viewmodel.base.IInstancesTabViewModel;
 import com.atlauncher.viewmodel.impl.InstancesTabViewModel;
@@ -35,7 +37,7 @@ public class InstancesTab extends HierarchyPanel implements Tab {
 
     private IInstancesTabViewModel viewModel;
     private InstancesNavigationPanel navigationPanel;
-    private InstancesListPanel instancesListPanel;
+    private HierarchyPanel instancesListPanel;
     private JScrollPane scrollPane;
 
     public InstancesTab() {
@@ -62,8 +64,11 @@ public class InstancesTab extends HierarchyPanel implements Tab {
     protected void onShow() {
         navigationPanel = new InstancesNavigationPanel(this, viewModel);
         this.add(this.navigationPanel, BorderLayout.NORTH);
-
-        instancesListPanel = new InstancesListPanel(this, viewModel);
+        if (App.settings.enableNewDesginLayout) {
+            instancesListPanel = new NewDesignInstancesListPanel(this, viewModel);
+        } else {
+            instancesListPanel = new InstancesListPanel(this, viewModel);
+        }
 
         scrollPane = Utils.wrapInVerticalScroller(this.instancesListPanel, 16);
 

--- a/src/main/java/com/atlauncher/gui/tabs/InstancesTab.java
+++ b/src/main/java/com/atlauncher/gui/tabs/InstancesTab.java
@@ -24,6 +24,7 @@ import javax.swing.JScrollPane;
 import org.mini2Dx.gettext.GetText;
 
 import com.atlauncher.App;
+import com.atlauncher.constants.UIConstants;
 import com.atlauncher.gui.panels.HierarchyPanel;
 import com.atlauncher.gui.tabs.instances.InstancesListPanel;
 import com.atlauncher.gui.tabs.instances.InstancesNavigationPanel;
@@ -64,10 +65,10 @@ public class InstancesTab extends HierarchyPanel implements Tab {
     protected void onShow() {
         navigationPanel = new InstancesNavigationPanel(this, viewModel);
         this.add(this.navigationPanel, BorderLayout.NORTH);
-        if (App.settings.enableNewDesginLayout) {
-            instancesListPanel = new NewDesignInstancesListPanel(this, viewModel);
-        } else {
+        if (App.settings.selectDesignLayout == UIConstants.LAYOUT_DEFAULT) {
             instancesListPanel = new InstancesListPanel(this, viewModel);
+        } else if (App.settings.selectDesignLayout == UIConstants.LAYOUT_GRID) {
+            instancesListPanel = new NewDesignInstancesListPanel(this, viewModel);
         }
 
         scrollPane = Utils.wrapInVerticalScroller(this.instancesListPanel, 16);

--- a/src/main/java/com/atlauncher/gui/tabs/ServersTab.java
+++ b/src/main/java/com/atlauncher/gui/tabs/ServersTab.java
@@ -67,7 +67,7 @@ public class ServersTab extends HierarchyPanel implements Tab, RelocalizationLis
 
     @Override
     protected void onShow() {
-        if (App.settings.enableNewDesginLayout) {
+        if (App.settings.selectDesignLayout == UIConstants.LAYOUT_GRID) {
             JPanel topPanel = new JPanel();
             topPanel.setLayout(new FlowLayout(FlowLayout.LEFT));
 
@@ -118,7 +118,7 @@ public class ServersTab extends HierarchyPanel implements Tab, RelocalizationLis
                 searchBox.requestFocus();
             });
             viewModel.getViewPosition().subscribe(scrollPane.getVerticalScrollBar()::setValue);
-        } else {
+        } else if (App.settings.selectDesignLayout == UIConstants.LAYOUT_DEFAULT) {
             JPanel topPanel = new JPanel();
             topPanel.setLayout(new FlowLayout(FlowLayout.RIGHT));
 

--- a/src/main/java/com/atlauncher/gui/tabs/ServersTab.java
+++ b/src/main/java/com/atlauncher/gui/tabs/ServersTab.java
@@ -24,17 +24,21 @@ import java.awt.GridBagLayout;
 import java.awt.event.KeyAdapter;
 import java.awt.event.KeyEvent;
 
+import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTextField;
 
 import org.mini2Dx.gettext.GetText;
 
+import com.atlauncher.App;
 import com.atlauncher.builders.HTMLBuilder;
 import com.atlauncher.constants.UIConstants;
 import com.atlauncher.evnt.listener.RelocalizationListener;
+import com.atlauncher.gui.card.NewDesignServerCard;
 import com.atlauncher.gui.card.NilCard;
 import com.atlauncher.gui.card.ServerCard;
+import com.atlauncher.gui.layouts.WrapLayout;
 import com.atlauncher.gui.panels.HierarchyPanel;
 import com.atlauncher.network.Analytics;
 import com.atlauncher.network.analytics.AnalyticsEvent;
@@ -63,65 +67,116 @@ public class ServersTab extends HierarchyPanel implements Tab, RelocalizationLis
 
     @Override
     protected void onShow() {
-        JPanel topPanel = new JPanel();
-        topPanel.setLayout(new FlowLayout(FlowLayout.RIGHT));
+        if (App.settings.enableNewDesginLayout) {
+            JPanel topPanel = new JPanel();
+            topPanel.setLayout(new FlowLayout(FlowLayout.LEFT));
 
-        searchBox = new JTextField(16);
-        addDisposable(
-            viewModel.getSearchObservable().subscribe(it -> searchBox.setText(it.orElse(null)))
-        );
-        searchBox.addKeyListener(new KeyAdapter() {
-            public void keyReleased(KeyEvent e) {
-                if (e.getKeyChar() == KeyEvent.VK_ENTER) {
-                    String text = searchBox.getText();
-                    Analytics.trackEvent(AnalyticsEvent.forSearchEvent("servers", text));
-                    viewModel.setSearchSubject(text);
+            searchBox = new JTextField(16);
+            viewModel.getSearchObservable().subscribe(it -> searchBox.setText(it.orElse(null)));
+            searchBox.addKeyListener(new KeyAdapter() {
+                public void keyReleased(KeyEvent e) {
+                    if (e.getKeyChar() == KeyEvent.VK_ENTER) {
+                        String text = searchBox.getText();
+                        Analytics.trackEvent(AnalyticsEvent.forSearchEvent("servers", text));
+                        viewModel.setSearchSubject(text);
+                    }
                 }
-            }
-        });
-        searchBox.putClientProperty("JTextField.placeholderText", GetText.tr("Search"));
-        searchBox.putClientProperty("JTextField.leadingIcon", new FlatSearchIcon());
-        searchBox.putClientProperty("JTextField.showClearButton", true);
-        searchBox.putClientProperty("JTextField.clearCallback", (Runnable) () -> viewModel.setSearchSubject(""));
-        topPanel.add(searchBox);
-
-        add(topPanel, BorderLayout.NORTH);
-
-        panel = new JPanel();
-        scrollPane = new JScrollPane(panel, JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED,
-            JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
-        scrollPane.getVerticalScrollBar().setUnitIncrement(16);
-        add(scrollPane, BorderLayout.CENTER);
-
-        panel.setLayout(new GridBagLayout());
-
-        addDisposable(viewModel.getServersObservable().subscribe(servers -> {
-            GridBagConstraints gbc = new GridBagConstraints();
-            gbc.gridx = gbc.gridy = 0;
-            gbc.weightx = 1.0;
-            gbc.insets = UIConstants.FIELD_INSETS_SMALL;
-            gbc.fill = GridBagConstraints.BOTH;
-
-            panel.removeAll();
-            gbc.gridy = 0;
-
-            servers.forEach(server -> {
-                panel.add(new ServerCard(server), gbc);
-                gbc.gridy++;
+            });
+            searchBox.putClientProperty("JTextField.placeholderText", GetText.tr("Search"));
+            searchBox.putClientProperty("JTextField.leadingIcon", new FlatSearchIcon());
+            searchBox.putClientProperty("JTextField.showClearButton", true);
+            searchBox.putClientProperty("JTextField.clearCallback", (Runnable) () -> {
+                viewModel.setSearchSubject("");
             });
 
-            if (panel.getComponentCount() == 0) {
-                panel.add(nilCard, gbc);
-            }
+            topPanel.add(searchBox);
 
-            validate();
-            repaint();
-            searchBox.requestFocus();
-        }));
+            add(topPanel, BorderLayout.NORTH);
 
-        addDisposable(
-            viewModel.getViewPosition().subscribe(scrollPane.getVerticalScrollBar()::setValue)
-        );
+            panel = new JPanel();
+            scrollPane = new JScrollPane(panel, JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED,
+                    JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
+            scrollPane.getVerticalScrollBar().setUnitIncrement(16);
+            add(scrollPane, BorderLayout.CENTER);
+
+            viewModel.getServersObservable().subscribe(servers -> {
+                viewModel.setViewPosition(scrollPane.getVerticalScrollBar().getValue());
+                panel.setLayout(new WrapLayout(WrapLayout.LEFT, 8, 8));
+                panel.removeAll();
+
+                servers.forEach(server -> {
+                    panel.add(new NewDesignServerCard(server));
+                });
+                if (servers.size() <= 0) {
+                    JLabel nothing = new JLabel("Nothing here");
+                    panel.setLayout(new FlowLayout(FlowLayout.CENTER));
+                    nothing.setFont(App.THEME.getBoldFont().deriveFont(24f));
+                    panel.add(nothing, BorderLayout.CENTER);
+                }
+                validate();
+                repaint();
+                searchBox.requestFocus();
+            });
+            viewModel.getViewPosition().subscribe(scrollPane.getVerticalScrollBar()::setValue);
+        } else {
+            JPanel topPanel = new JPanel();
+            topPanel.setLayout(new FlowLayout(FlowLayout.RIGHT));
+
+            searchBox = new JTextField(16);
+            addDisposable(
+                    viewModel.getSearchObservable().subscribe(it -> searchBox.setText(it.orElse(null))));
+            searchBox.addKeyListener(new KeyAdapter() {
+                public void keyReleased(KeyEvent e) {
+                    if (e.getKeyChar() == KeyEvent.VK_ENTER) {
+                        String text = searchBox.getText();
+                        Analytics.trackEvent(AnalyticsEvent.forSearchEvent("servers", text));
+                        viewModel.setSearchSubject(text);
+                    }
+                }
+            });
+            searchBox.putClientProperty("JTextField.placeholderText", GetText.tr("Search"));
+            searchBox.putClientProperty("JTextField.leadingIcon", new FlatSearchIcon());
+            searchBox.putClientProperty("JTextField.showClearButton", true);
+            searchBox.putClientProperty("JTextField.clearCallback", (Runnable) () -> viewModel.setSearchSubject(""));
+            topPanel.add(searchBox);
+
+            add(topPanel, BorderLayout.NORTH);
+
+            panel = new JPanel();
+            scrollPane = new JScrollPane(panel, JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED,
+                    JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
+            scrollPane.getVerticalScrollBar().setUnitIncrement(16);
+            add(scrollPane, BorderLayout.CENTER);
+
+            panel.setLayout(new GridBagLayout());
+
+            addDisposable(viewModel.getServersObservable().subscribe(servers -> {
+                GridBagConstraints gbc = new GridBagConstraints();
+                gbc.gridx = gbc.gridy = 0;
+                gbc.weightx = 1.0;
+                gbc.insets = UIConstants.FIELD_INSETS_SMALL;
+                gbc.fill = GridBagConstraints.BOTH;
+
+                panel.removeAll();
+                gbc.gridy = 0;
+
+                servers.forEach(server -> {
+                    panel.add(new ServerCard(server), gbc);
+                    gbc.gridy++;
+                });
+
+                if (panel.getComponentCount() == 0) {
+                    panel.add(nilCard, gbc);
+                }
+
+                validate();
+                repaint();
+                searchBox.requestFocus();
+            }));
+
+            addDisposable(
+                    viewModel.getViewPosition().subscribe(scrollPane.getVerticalScrollBar()::setValue));
+        }
     }
 
     @Override

--- a/src/main/java/com/atlauncher/gui/tabs/instances/NewDesignInstancesListPanel.java
+++ b/src/main/java/com/atlauncher/gui/tabs/instances/NewDesignInstancesListPanel.java
@@ -1,0 +1,102 @@
+/*
+ * ATLauncher - https://github.com/ATLauncher/ATLauncher
+ * Copyright (C) 2013-2022 ATLauncher
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.atlauncher.gui.tabs.instances;
+
+import java.util.stream.Collectors;
+
+import org.mini2Dx.gettext.GetText;
+
+import com.atlauncher.builders.HTMLBuilder;
+import com.atlauncher.evnt.listener.RelocalizationListener;
+import com.atlauncher.gui.card.NewDesignInstanceCard;
+import com.atlauncher.gui.card.NilCard;
+import com.atlauncher.gui.layouts.WrapLayout;
+import com.atlauncher.gui.panels.HierarchyPanel;
+import com.atlauncher.gui.tabs.InstancesTab;
+import com.atlauncher.managers.PerformanceManager;
+import com.atlauncher.viewmodel.base.IInstancesTabViewModel;
+
+public final class NewDesignInstancesListPanel extends HierarchyPanel
+        implements RelocalizationListener {
+
+    private final InstancesTab instancesTab;
+    private final IInstancesTabViewModel viewModel;
+
+    private final NilCard nilCard = new NilCard(
+            getNilMessage(),
+            new NilCard.Action[] {
+                    NilCard.Action.createCreatePackAction(),
+                    NilCard.Action.createDownloadPackAction()
+            });
+
+    public NewDesignInstancesListPanel(InstancesTab instancesTab, final IInstancesTabViewModel viewModel) {
+        super(new WrapLayout(WrapLayout.LEFT, 8, 8));
+        // columns and gaps
+        this.instancesTab = instancesTab;
+        this.viewModel = viewModel;
+        PerformanceManager.start("Displaying Instances");
+    }
+
+    private static String getNilMessage() {
+        return new HTMLBuilder()
+                .text(GetText.tr("There are no instances to display.<br/><br/>Install one from the Packs tab."))
+                .build();
+    }
+
+    @Override
+    protected void onShow() {
+        addDisposable(viewModel.getInstancesList()
+                .map(instancesList -> {
+                    viewModel.setIsLoading(true);
+                    return instancesList.instances.stream().map(instance -> new NewDesignInstanceCard(
+                            instance.instance,
+                            instance.hasUpdate,
+                            instancesList.instanceTitleFormat)).collect(Collectors.toList());
+                }).subscribe(instances -> {
+                    removeAll();
+
+                    if (instances.isEmpty()) {
+                        this.add(this.nilCard);
+                    } else {
+                        PerformanceManager.start("Render cards");
+                        instances.forEach(instance -> {
+                            this.add(instance);
+                        });
+
+                        validate();
+                        repaint();
+                        PerformanceManager.end("Render cards");
+                    }
+
+                    viewModel.setIsLoading(false);
+
+                    // After repainting is done, let scroll view resume
+                    invokeLater(() -> instancesTab.setScroll(viewModel.getScroll()));
+                    PerformanceManager.end("Displaying Instances");
+                }));
+    }
+
+    @Override
+    protected void createViewModel() {
+    }
+
+    @Override
+    protected void onDestroy() {
+        removeAll();
+    }
+}

--- a/src/main/java/com/atlauncher/gui/tabs/settings/GeneralSettingsTab.java
+++ b/src/main/java/com/atlauncher/gui/tabs/settings/GeneralSettingsTab.java
@@ -295,6 +295,37 @@ public class GeneralSettingsTab extends AbstractSettingsTab {
 
         add(customDownloadsPathPanel, gbc);
 
+        
+                // region change design layout
+
+                gbc.gridx = 0;
+                gbc.gridy++;
+                gbc.insets = UIConstants.LABEL_INSETS;
+                gbc.anchor = GridBagConstraints.BASELINE_TRAILING;
+
+                JLabelWithHover selectedDesignLayoutLabel = new JLabelWithHover(GetText.tr("Design Layout") + ":",
+                                HELP_ICON,
+                                GetText.tr("change instances/server tab layout"));
+
+                add(selectedDesignLayoutLabel, gbc);
+
+                gbc.gridx++;
+                gbc.insets = UIConstants.FIELD_INSETS;
+                gbc.anchor = GridBagConstraints.BASELINE_LEADING;
+                JComboBox<ComboItem<Integer>> selectDesginLayout = new JComboBox<>();
+                selectDesginLayout.addItem(new ComboItem<>(UIConstants.LAYOUT_DEFAULT, GetText.tr("Default")));
+                selectDesginLayout.addItem(new ComboItem<>(UIConstants.LAYOUT_GRID, GetText.tr("Grid")));
+
+                addDisposable(viewModel.getDesignLayout().subscribe(selectDesginLayout::setSelectedIndex));
+
+                selectDesginLayout.addItemListener(itemEvent -> {
+                        if (itemEvent.getStateChange() == ItemEvent.SELECTED)
+                                viewModel.setDesignLayout(((ComboItem<Integer>) itemEvent.getItem()).getValue());
+                });
+
+                add(selectDesginLayout, gbc);
+
+
         // Keep Launcher Open
 
         gbc.gridx = 0;
@@ -545,14 +576,6 @@ public class GeneralSettingsTab extends AbstractSettingsTab {
         JLabelWithHover newDesignLabel = new JLabelWithHover(GetText.tr("Enable New Layout") + "?", HELP_ICON,
                 GetText.tr("enable this option to try the new redesigned instances/server ui"));
         add(newDesignLabel, gbc);
-        // region new layout
-        gbc.gridx++;
-        gbc.insets = UIConstants.CHECKBOX_FIELD_INSETS;
-        gbc.anchor = GridBagConstraints.BASELINE_LEADING;
-        JCheckBox newDesginEnabled = new JCheckBox();
-        newDesginEnabled.addItemListener(e -> viewModel.setNewDesignLayout(e.getStateChange() == ItemEvent.SELECTED));
-        addDisposable(viewModel.getNewDesignLayout().subscribe(newDesginEnabled::setSelected));
-        add(newDesginEnabled, gbc);
     }
 
     @Override

--- a/src/main/java/com/atlauncher/gui/tabs/settings/GeneralSettingsTab.java
+++ b/src/main/java/com/atlauncher/gui/tabs/settings/GeneralSettingsTab.java
@@ -62,7 +62,7 @@ public class GeneralSettingsTab extends AbstractSettingsTab {
         gbc.anchor = GridBagConstraints.BELOW_BASELINE_TRAILING;
 
         JLabelWithHover languageLabel = new JLabelWithHover(GetText.tr("Language") + ":", HELP_ICON,
-            GetText.tr("This specifies the language used by the Launcher."));
+                GetText.tr("This specifies the language used by the Launcher."));
         add(languageLabel, gbc);
 
         gbc.gridx++;
@@ -71,7 +71,6 @@ public class GeneralSettingsTab extends AbstractSettingsTab {
 
         JPanel languagePanel = new JPanel();
         languagePanel.setLayout(new BoxLayout(languagePanel, BoxLayout.X_AXIS));
-
 
         JComboBox<String> language = new JComboBox<>(viewModel.getLanguages());
         language.addItemListener(itemEvent -> {
@@ -97,7 +96,7 @@ public class GeneralSettingsTab extends AbstractSettingsTab {
         gbc.anchor = GridBagConstraints.BASELINE_TRAILING;
 
         JLabelWithHover themeLabel = new JLabelWithHover(GetText.tr("Theme") + ":", HELP_ICON,
-            GetText.tr("This sets the theme that the launcher will use."));
+                GetText.tr("This sets the theme that the launcher will use."));
 
         add(themeLabel, gbc);
 
@@ -126,7 +125,7 @@ public class GeneralSettingsTab extends AbstractSettingsTab {
         gbc.anchor = GridBagConstraints.BASELINE_TRAILING;
 
         JLabelWithHover dateFormatLabel = new JLabelWithHover(GetText.tr("Date Format") + ":", HELP_ICON,
-            GetText.tr("This controls the format that dates are displayed in the launcher."));
+                GetText.tr("This controls the format that dates are displayed in the launcher."));
 
         add(dateFormatLabel, gbc);
 
@@ -158,7 +157,7 @@ public class GeneralSettingsTab extends AbstractSettingsTab {
         gbc.anchor = GridBagConstraints.BASELINE_TRAILING;
 
         JLabelWithHover instanceTitleFormatLabel = new JLabelWithHover(GetText.tr("Instance Title Format") + ":",
-            HELP_ICON, GetText.tr("This controls the format that instances titles are shown as."));
+                HELP_ICON, GetText.tr("This controls the format that instances titles are shown as."));
 
         add(instanceTitleFormatLabel, gbc);
 
@@ -174,7 +173,7 @@ public class GeneralSettingsTab extends AbstractSettingsTab {
 
         for (String format : viewModel.getInstanceTitleFormats()) {
             instanceTitleFormat.addItem(new ComboItem<>(format, String.format(format, GetText.tr("Instance Name"),
-                GetText.tr("Pack Name"), GetText.tr("Pack Version"), GetText.tr("Minecraft Version"))));
+                    GetText.tr("Pack Name"), GetText.tr("Pack Version"), GetText.tr("Minecraft Version"))));
         }
 
         addDisposable(viewModel.getInstanceFormat().subscribe(instanceTitleFormat::setSelectedIndex));
@@ -189,7 +188,7 @@ public class GeneralSettingsTab extends AbstractSettingsTab {
         gbc.anchor = GridBagConstraints.BASELINE_TRAILING;
 
         JLabelWithHover selectedTabOnStartupLabel = new JLabelWithHover(GetText.tr("Default Tab") + ":", HELP_ICON,
-            GetText.tr("Which tab to have selected by default when opening the launcher."));
+                GetText.tr("Which tab to have selected by default when opening the launcher."));
 
         add(selectedTabOnStartupLabel, gbc);
 
@@ -199,7 +198,7 @@ public class GeneralSettingsTab extends AbstractSettingsTab {
         JComboBox<ComboItem<Integer>> selectedTabOnStartup = new JComboBox<>();
         selectedTabOnStartup.addItem(new ComboItem<>(UIConstants.LAUNCHER_NEWS_TAB, GetText.tr("News")));
         selectedTabOnStartup
-            .addItem(new ComboItem<>(UIConstants.LAUNCHER_CREATE_PACK_TAB, GetText.tr("Create Pack")));
+                .addItem(new ComboItem<>(UIConstants.LAUNCHER_CREATE_PACK_TAB, GetText.tr("Create Pack")));
         selectedTabOnStartup.addItem(new ComboItem<>(UIConstants.LAUNCHER_PACKS_TAB, GetText.tr("Packs")));
         selectedTabOnStartup.addItem(new ComboItem<>(UIConstants.LAUNCHER_INSTANCES_TAB, GetText.tr("Instances")));
         selectedTabOnStartup.addItem(new ComboItem<>(UIConstants.LAUNCHER_SERVERS_TAB, GetText.tr("Servers")));
@@ -224,15 +223,16 @@ public class GeneralSettingsTab extends AbstractSettingsTab {
         gbc.anchor = GridBagConstraints.BASELINE_TRAILING;
 
         JLabelWithHover defaultInstanceSortingLabel = new JLabelWithHover(GetText.tr("Default Instance Sort") + ":",
-            HELP_ICON,
-            GetText.tr("Default sorting of instances under the Instances tab."));
+                HELP_ICON,
+                GetText.tr("Default sorting of instances under the Instances tab."));
 
         add(defaultInstanceSortingLabel, gbc);
 
         gbc.gridx++;
         gbc.insets = UIConstants.FIELD_INSETS;
         gbc.anchor = GridBagConstraints.BASELINE_LEADING;
-        JComboBox<InstanceSortingStrategies> defaultInstanceSorting = new JComboBox<>(InstanceSortingStrategies.values());
+        JComboBox<InstanceSortingStrategies> defaultInstanceSorting = new JComboBox<>(
+                InstanceSortingStrategies.values());
         defaultInstanceSorting.addItemListener(itemEvent -> {
             if (itemEvent.getStateChange() == ItemEvent.SELECTED)
                 viewModel.setInstanceSorting((InstanceSortingStrategies) itemEvent.getItem());
@@ -249,9 +249,9 @@ public class GeneralSettingsTab extends AbstractSettingsTab {
         gbc.insets = UIConstants.LABEL_INSETS;
         gbc.anchor = GridBagConstraints.BASELINE_TRAILING;
         JLabelWithHover customDownloadsPathLabel = new JLabelWithHover(GetText.tr("Downloads Folder") + ":", HELP_ICON,
-            new HTMLBuilder().center().split(100).text(GetText.tr(
-                    "This setting allows you to change the Downloads folder that the launcher looks in when downloading browser mods."))
-                .build());
+                new HTMLBuilder().center().split(100).text(GetText.tr(
+                        "This setting allows you to change the Downloads folder that the launcher looks in when downloading browser mods."))
+                        .build());
         add(customDownloadsPathLabel, gbc);
 
         gbc.gridx++;
@@ -263,17 +263,15 @@ public class GeneralSettingsTab extends AbstractSettingsTab {
         JTextField customDownloadsPath = new JTextField(16);
         addDisposable(viewModel.getCustomsDownloadPath().subscribe(customDownloadsPath::setText));
         customDownloadsPath.addKeyListener(
-            new DelayedSavingKeyListener(
-                100,
-                () -> viewModel.setCustomsDownloadPath(customDownloadsPath.getText()),
-                viewModel::setCustomsDownloadPathPending
-            )
-        );
+                new DelayedSavingKeyListener(
+                        100,
+                        () -> viewModel.setCustomsDownloadPath(customDownloadsPath.getText()),
+                        viewModel::setCustomsDownloadPathPending));
 
         JButton customDownloadsPathResetButton = new JButton(GetText.tr("Reset"));
 
         customDownloadsPathResetButton.addActionListener(
-            e -> viewModel.resetCustomDownloadPath());
+                e -> viewModel.resetCustomDownloadPath());
 
         JButton customDownloadsPathBrowseButton = new JButton(GetText.tr("Browse"));
         customDownloadsPathBrowseButton.addActionListener(e -> {
@@ -304,7 +302,7 @@ public class GeneralSettingsTab extends AbstractSettingsTab {
         gbc.insets = UIConstants.LABEL_INSETS;
         gbc.anchor = GridBagConstraints.BASELINE_TRAILING;
         JLabelWithHover keepLauncherOpenLabel = new JLabelWithHover(GetText.tr("Keep Launcher Open") + "?", HELP_ICON,
-            GetText.tr("This determines if ATLauncher should stay open or exit after Minecraft has exited"));
+                GetText.tr("This determines if ATLauncher should stay open or exit after Minecraft has exited"));
         add(keepLauncherOpenLabel, gbc);
 
         gbc.gridx++;
@@ -322,7 +320,7 @@ public class GeneralSettingsTab extends AbstractSettingsTab {
         gbc.insets = UIConstants.LABEL_INSETS;
         gbc.anchor = GridBagConstraints.BASELINE_TRAILING;
         JLabelWithHover enableConsoleLabel = new JLabelWithHover(GetText.tr("Enable Console") + "?", HELP_ICON,
-            GetText.tr("If you want the console to be visible when opening the Launcher."));
+                GetText.tr("If you want the console to be visible when opening the Launcher."));
         add(enableConsoleLabel, gbc);
 
         gbc.gridx++;
@@ -340,9 +338,9 @@ public class GeneralSettingsTab extends AbstractSettingsTab {
         gbc.insets = UIConstants.LABEL_INSETS;
         gbc.anchor = GridBagConstraints.BASELINE_TRAILING;
         JLabelWithHover enableTrayIconLabel = new JLabelWithHover(GetText.tr("Enable Tray Menu") + "?", HELP_ICON,
-            new HTMLBuilder().center().split(100).text(GetText.tr(
-                    "The Tray Menu is a little icon that shows in your system taskbar which allows you to perform different functions to do various things with the launcher such as hiding or showing the console, killing Minecraft or closing ATLauncher."))
-                .build());
+                new HTMLBuilder().center().split(100).text(GetText.tr(
+                        "The Tray Menu is a little icon that shows in your system taskbar which allows you to perform different functions to do various things with the launcher such as hiding or showing the console, killing Minecraft or closing ATLauncher."))
+                        .build());
         add(enableTrayIconLabel, gbc);
 
         gbc.gridx++;
@@ -360,15 +358,16 @@ public class GeneralSettingsTab extends AbstractSettingsTab {
         gbc.insets = UIConstants.LABEL_INSETS;
         gbc.anchor = GridBagConstraints.BASELINE_TRAILING;
         JLabelWithHover enableDiscordIntegrationLabel = new JLabelWithHover(
-            GetText.tr("Enable Discord Integration") + "?", HELP_ICON,
-            GetText.tr("This will enable showing which pack you're playing in Discord."));
+                GetText.tr("Enable Discord Integration") + "?", HELP_ICON,
+                GetText.tr("This will enable showing which pack you're playing in Discord."));
         add(enableDiscordIntegrationLabel, gbc);
 
         gbc.gridx++;
         gbc.insets = UIConstants.CHECKBOX_FIELD_INSETS;
         gbc.anchor = GridBagConstraints.BASELINE_LEADING;
         JCheckBox enableDiscordIntegration = new JCheckBox();
-        enableDiscordIntegration.addItemListener(e -> viewModel.setEnableDiscordIntegration(e.getStateChange() == ItemEvent.SELECTED));
+        enableDiscordIntegration
+                .addItemListener(e -> viewModel.setEnableDiscordIntegration(e.getStateChange() == ItemEvent.SELECTED));
         addDisposable(viewModel.getEnableDiscordIntegration().subscribe(enableDiscordIntegration::setSelected));
         enableDiscordIntegration.setEnabled(!OS.isArm());
         add(enableDiscordIntegration, gbc);
@@ -383,21 +382,20 @@ public class GeneralSettingsTab extends AbstractSettingsTab {
             gbc.insets = UIConstants.LABEL_INSETS;
             gbc.anchor = GridBagConstraints.BASELINE_TRAILING;
             JLabelWithHover enableFeralGamemodeLabel = new JLabelWithHover(GetText.tr("Enable Feral Gamemode") + "?",
-                HELP_ICON, GetText.tr("This will enable Feral Gamemode for packs launched."));
+                    HELP_ICON, GetText.tr("This will enable Feral Gamemode for packs launched."));
             add(enableFeralGamemodeLabel, gbc);
 
             gbc.gridx++;
             gbc.insets = UIConstants.CHECKBOX_FIELD_INSETS;
             gbc.anchor = GridBagConstraints.BASELINE_LEADING;
             JCheckBox enableFeralGamemode = new JCheckBox();
-            enableFeralGamemode.addItemListener(e ->
-                viewModel.setEnableFeralGameMode(e.getStateChange() == ItemEvent.SELECTED)
-            );
+            enableFeralGamemode
+                    .addItemListener(e -> viewModel.setEnableFeralGameMode(e.getStateChange() == ItemEvent.SELECTED));
             addDisposable(viewModel.getEnableFeralGameMode().subscribe(enableFeralGamemode::setSelected));
 
             if (!gameModeExistsInPath) {
                 enableFeralGamemodeLabel.setToolTipText(GetText.tr(
-                    "This will enable Feral Gamemode for packs launched (disabled because gamemoderun not found in PATH, please install Feral Gamemode or add it to your PATH)."));
+                        "This will enable Feral Gamemode for packs launched (disabled because gamemoderun not found in PATH, please install Feral Gamemode or add it to your PATH)."));
                 enableFeralGamemodeLabel.setEnabled(false);
 
                 enableFeralGamemode.setEnabled(false);
@@ -413,9 +411,9 @@ public class GeneralSettingsTab extends AbstractSettingsTab {
         gbc.insets = UIConstants.LABEL_INSETS;
         gbc.anchor = GridBagConstraints.BASELINE_TRAILING;
         JLabelWithHover disableCustomFontsLabel = new JLabelWithHover(GetText.tr("Disable Custom Fonts?"), HELP_ICON,
-            new HTMLBuilder().center().split(100).text(GetText.tr(
-                    "This will disable custom fonts used by themes. If your system has issues with font display not looking right, you can disable this to switch to a default compatible font."))
-                .build());
+                new HTMLBuilder().center().split(100).text(GetText.tr(
+                        "This will disable custom fonts used by themes. If your system has issues with font display not looking right, you can disable this to switch to a default compatible font."))
+                        .build());
         add(disableCustomFontsLabel, gbc);
 
         gbc.gridx++;
@@ -435,19 +433,18 @@ public class GeneralSettingsTab extends AbstractSettingsTab {
         gbc.insets = UIConstants.LABEL_INSETS;
         gbc.anchor = GridBagConstraints.BASELINE_TRAILING;
         JLabelWithHover rememberWindowSizePositionLabel = new JLabelWithHover(
-            GetText.tr("Remember Window Size & Positions?"), HELP_ICON,
-            new HTMLBuilder().center().split(100).text(GetText.tr(
-                    "This will remember the windows positions and size so they keep the same size and position when you restart the launcher."))
-                .build());
+                GetText.tr("Remember Window Size & Positions?"), HELP_ICON,
+                new HTMLBuilder().center().split(100).text(GetText.tr(
+                        "This will remember the windows positions and size so they keep the same size and position when you restart the launcher."))
+                        .build());
         add(rememberWindowSizePositionLabel, gbc);
 
         gbc.gridx++;
         gbc.insets = UIConstants.CHECKBOX_FIELD_INSETS;
         gbc.anchor = GridBagConstraints.BASELINE_LEADING;
         JCheckBox rememberWindowSizePosition = new JCheckBox();
-        rememberWindowSizePosition.addItemListener(e ->
-            viewModel.setRememberWindowStuff(e.getStateChange() == ItemEvent.SELECTED)
-        );
+        rememberWindowSizePosition
+                .addItemListener(e -> viewModel.setRememberWindowStuff(e.getStateChange() == ItemEvent.SELECTED));
         addDisposable(viewModel.getRememberWindowSizePosition().subscribe(rememberWindowSizePosition::setSelected));
         add(rememberWindowSizePosition, gbc);
 
@@ -458,20 +455,20 @@ public class GeneralSettingsTab extends AbstractSettingsTab {
             gbc.gridy++;
             gbc.insets = UIConstants.LABEL_INSETS;
             gbc.anchor = GridBagConstraints.BASELINE_TRAILING;
-            JLabelWithHover useNativeFilePickerLabel = new JLabelWithHover(GetText.tr("Use Native File Picker?"), HELP_ICON,
-                new HTMLBuilder().center().split(100)
-                    .text(GetText
-                        .tr("This will use your operating systems native file picker when selecting files."))
-                    .build());
+            JLabelWithHover useNativeFilePickerLabel = new JLabelWithHover(GetText.tr("Use Native File Picker?"),
+                    HELP_ICON,
+                    new HTMLBuilder().center().split(100)
+                            .text(GetText
+                                    .tr("This will use your operating systems native file picker when selecting files."))
+                            .build());
             add(useNativeFilePickerLabel, gbc);
 
             gbc.gridx++;
             gbc.insets = UIConstants.CHECKBOX_FIELD_INSETS;
             gbc.anchor = GridBagConstraints.BASELINE_LEADING;
             JCheckBox useNativeFilePicker = new JCheckBox();
-            useNativeFilePicker.addItemListener(e ->
-                viewModel.setUseNativeFilePicker(e.getStateChange() == ItemEvent.SELECTED)
-            );
+            useNativeFilePicker
+                    .addItemListener(e -> viewModel.setUseNativeFilePicker(e.getStateChange() == ItemEvent.SELECTED));
             addDisposable(viewModel.getUseNativeFilePicker().subscribe(useNativeFilePicker::setSelected));
             add(useNativeFilePicker, gbc);
         }
@@ -483,19 +480,17 @@ public class GeneralSettingsTab extends AbstractSettingsTab {
         gbc.insets = UIConstants.LABEL_INSETS;
         gbc.anchor = GridBagConstraints.BASELINE_TRAILING;
         JLabelWithHover useRecycleBinLabel = new JLabelWithHover(GetText.tr("Use Recycle Bin/Trash?"), HELP_ICON,
-            new HTMLBuilder().center().split(100)
-                .text(GetText
-                    .tr("This will use your operating systems recycle bin/trash where possible when deleting files/instances/servers instead of just deleting them entirely, allowing you to recover files if you make a mistake or want to get them back."))
-                .build());
+                new HTMLBuilder().center().split(100)
+                        .text(GetText
+                                .tr("This will use your operating systems recycle bin/trash where possible when deleting files/instances/servers instead of just deleting them entirely, allowing you to recover files if you make a mistake or want to get them back."))
+                        .build());
         add(useRecycleBinLabel, gbc);
 
         gbc.gridx++;
         gbc.insets = UIConstants.CHECKBOX_FIELD_INSETS;
         gbc.anchor = GridBagConstraints.BASELINE_LEADING;
         JCheckBox useRecycleBin = new JCheckBox();
-        useRecycleBin.addItemListener(e ->
-            viewModel.setUseRecycleBin(e.getStateChange() == ItemEvent.SELECTED)
-        );
+        useRecycleBin.addItemListener(e -> viewModel.setUseRecycleBin(e.getStateChange() == ItemEvent.SELECTED));
         addDisposable(viewModel.getUseRecycleBin().subscribe(useRecycleBin::setSelected));
         add(useRecycleBin, gbc);
 
@@ -507,19 +502,17 @@ public class GeneralSettingsTab extends AbstractSettingsTab {
             gbc.insets = UIConstants.LABEL_INSETS;
             gbc.anchor = GridBagConstraints.BASELINE_TRAILING;
             JLabelWithHover enableArmSupportLabel = new JLabelWithHover(GetText.tr("Enable ARM Support?"), HELP_ICON,
-                new HTMLBuilder().center().split(100)
-                    .text(GetText
-                        .tr("Support for ARM devices is still experimental. If you experience issues on an ARM based device, please turn this off."))
-                    .build());
+                    new HTMLBuilder().center().split(100)
+                            .text(GetText
+                                    .tr("Support for ARM devices is still experimental. If you experience issues on an ARM based device, please turn this off."))
+                            .build());
             add(enableArmSupportLabel, gbc);
 
             gbc.gridx++;
             gbc.insets = UIConstants.CHECKBOX_FIELD_INSETS;
             gbc.anchor = GridBagConstraints.BASELINE_LEADING;
             JCheckBox enableArmSupport = new JCheckBox();
-            useRecycleBin.addItemListener(e ->
-                viewModel.setEnableArmSupport(e.getStateChange() == ItemEvent.SELECTED)
-            );
+            useRecycleBin.addItemListener(e -> viewModel.setEnableArmSupport(e.getStateChange() == ItemEvent.SELECTED));
             addDisposable(viewModel.getEnableArmSupport().subscribe(useRecycleBin::setSelected));
             add(enableArmSupport, gbc);
         }
@@ -530,10 +523,10 @@ public class GeneralSettingsTab extends AbstractSettingsTab {
         gbc.insets = UIConstants.LABEL_INSETS;
         gbc.anchor = GridBagConstraints.BASELINE_TRAILING;
         JLabelWithHover scanModsOnLaunchLabel = new JLabelWithHover(GetText.tr("Scan Mods On Launch?"), HELP_ICON,
-            new HTMLBuilder().center().split(100)
-                .text(GetText.tr(
-                    "This will scan the mods in instances before launching to ensure they do not contain malware or have been modified since installing."))
-                .build());
+                new HTMLBuilder().center().split(100)
+                        .text(GetText.tr(
+                                "This will scan the mods in instances before launching to ensure they do not contain malware or have been modified since installing."))
+                        .build());
         add(scanModsOnLaunchLabel, gbc);
 
         gbc.gridx++;
@@ -541,11 +534,25 @@ public class GeneralSettingsTab extends AbstractSettingsTab {
         gbc.anchor = GridBagConstraints.BASELINE_LEADING;
         JCheckBox scanModsOnLaunch = new JCheckBox();
         scanModsOnLaunch.setSelected(App.settings.scanModsOnLaunch);
-        scanModsOnLaunch.addItemListener(e ->
-            viewModel.setScanModsOnLaunch(e.getStateChange() == ItemEvent.SELECTED)
-        );
+        scanModsOnLaunch.addItemListener(e -> viewModel.setScanModsOnLaunch(e.getStateChange() == ItemEvent.SELECTED));
         addDisposable(viewModel.getScanModsOnLaunch().subscribe(scanModsOnLaunch::setSelected));
         add(scanModsOnLaunch, gbc);
+
+        gbc.gridx = 0;
+        gbc.gridy++;
+        gbc.insets = UIConstants.LABEL_INSETS;
+        gbc.anchor = GridBagConstraints.BASELINE_TRAILING;
+        JLabelWithHover newDesignLabel = new JLabelWithHover(GetText.tr("Enable New Layout") + "?", HELP_ICON,
+                GetText.tr("enable this option to try the new redesigned instances/server ui"));
+        add(newDesignLabel, gbc);
+        // region new layout
+        gbc.gridx++;
+        gbc.insets = UIConstants.CHECKBOX_FIELD_INSETS;
+        gbc.anchor = GridBagConstraints.BASELINE_LEADING;
+        JCheckBox newDesginEnabled = new JCheckBox();
+        newDesginEnabled.addItemListener(e -> viewModel.setNewDesignLayout(e.getStateChange() == ItemEvent.SELECTED));
+        addDisposable(viewModel.getNewDesignLayout().subscribe(newDesginEnabled::setSelected));
+        add(newDesginEnabled, gbc);
     }
 
     @Override

--- a/src/main/java/com/atlauncher/viewmodel/impl/settings/GeneralSettingsViewModel.java
+++ b/src/main/java/com/atlauncher/viewmodel/impl/settings/GeneralSettingsViewModel.java
@@ -50,33 +50,31 @@ import io.reactivex.rxjava3.subjects.BehaviorSubject;
 
 /**
  * @since 2022 / 06 / 15
- * <p>
- * View model for {@link GeneralSettingsTab}
+ *        <p>
+ *        View model for {@link GeneralSettingsTab}
  */
 public class GeneralSettingsViewModel implements SettingsListener {
-    private final BehaviorSubject<Integer>
-        _addOnSelectedLanguage = BehaviorSubject.create(),
-        _selectedTheme = BehaviorSubject.create(),
-        _dateFormat = BehaviorSubject.create(),
-        _addOnInstanceFormat = BehaviorSubject.create(),
-        _addOnSelectedTabOnStartup = BehaviorSubject.create(),
-        _addInstanceSorting = BehaviorSubject.create();
+    private final BehaviorSubject<Integer> _addOnSelectedLanguage = BehaviorSubject.create(),
+            _selectedTheme = BehaviorSubject.create(),
+            _dateFormat = BehaviorSubject.create(),
+            _addOnInstanceFormat = BehaviorSubject.create(),
+            _addOnSelectedTabOnStartup = BehaviorSubject.create(),
+            _addInstanceSorting = BehaviorSubject.create();
 
-    private final BehaviorSubject<String>
-        _addOnCustomsDownloadPath = BehaviorSubject.create();
+    private final BehaviorSubject<String> _addOnCustomsDownloadPath = BehaviorSubject.create();
 
-    private final BehaviorSubject<Boolean>
-        _keepLauncherOpen = BehaviorSubject.create(),
-        _enableConsole = BehaviorSubject.create(),
-        _enableTrayMenu = BehaviorSubject.create(),
-        _enableDiscordIntegration = BehaviorSubject.create(),
-        _enableFeralGameMode = BehaviorSubject.create(),
-        _disableCustomFonts = BehaviorSubject.create(),
-        _rememberWindowSizePosition = BehaviorSubject.create(),
-        _useNativeFilePicker = BehaviorSubject.create(),
-        _useRecycleBin = BehaviorSubject.create(),
-        enableArmSupport = BehaviorSubject.create(),
-        scanModsOnLaunch = BehaviorSubject.create();
+    private final BehaviorSubject<Boolean> _keepLauncherOpen = BehaviorSubject.create(),
+            _enableConsole = BehaviorSubject.create(),
+            _enableTrayMenu = BehaviorSubject.create(),
+            _enableDiscordIntegration = BehaviorSubject.create(),
+            _enableFeralGameMode = BehaviorSubject.create(),
+            _disableCustomFonts = BehaviorSubject.create(),
+            _rememberWindowSizePosition = BehaviorSubject.create(),
+            _useNativeFilePicker = BehaviorSubject.create(),
+            _useRecycleBin = BehaviorSubject.create(),
+            enableArmSupport = BehaviorSubject.create(),
+            scanModsOnLaunch = BehaviorSubject.create(),
+            _newDesignLayout = BehaviorSubject.create();
 
     private List<LauncherTheme> themes = null;
 
@@ -95,7 +93,7 @@ public class GeneralSettingsViewModel implements SettingsListener {
         pushInstanceSorting();
 
         _addOnCustomsDownloadPath.onNext(Optional.ofNullable(App.settings.customDownloadsPath)
-            .orElse(FileSystem.getUserDownloadsPath(false).toString()));
+                .orElse(FileSystem.getUserDownloadsPath(false).toString()));
 
         _keepLauncherOpen.onNext(App.settings.keepLauncherOpen);
         _enableConsole.onNext(App.settings.enableConsole);
@@ -106,13 +104,14 @@ public class GeneralSettingsViewModel implements SettingsListener {
         _rememberWindowSizePosition.onNext(App.settings.rememberWindowSizePosition);
         _useNativeFilePicker.onNext(App.settings.useNativeFilePicker);
         _useRecycleBin.onNext(App.settings.useRecycleBin);
+        _newDesignLayout.onNext(App.settings.enableNewDesginLayout);
     }
 
     /**
      * Get the languages to have as options.
      * <p>
      * TODO Upon implementation of translations, ensure the returned value is
-     *  cached in the view model to avoid extra processing.
+     * cached in the view model to avoid extra processing.
      *
      * @return languages
      */
@@ -156,18 +155,17 @@ public class GeneralSettingsViewModel implements SettingsListener {
     public List<LauncherTheme> getThemes() {
         if (themes == null)
             themes = Arrays.asList(
-                new LauncherTheme("com.atlauncher.themes.Dark", "ATLauncher Dark (default)"),
-                new LauncherTheme("com.atlauncher.themes.Light", "ATLauncher Light"),
-                new LauncherTheme("com.atlauncher.themes.MonokaiPro", "Monokai Pro"),
-                new LauncherTheme("com.atlauncher.themes.DraculaContrast", "Dracula Contrast"),
-                new LauncherTheme("com.atlauncher.themes.HiberbeeDark", "Hiberbee Dark"),
-                new LauncherTheme("com.atlauncher.themes.Vuesion", "Vuesion"),
-                new LauncherTheme("com.atlauncher.themes.MaterialPalenightContrast", "Material Palenight Contrast"),
-                new LauncherTheme("com.atlauncher.themes.ArcOrange", "Arc Orange"),
-                new LauncherTheme("com.atlauncher.themes.CyanLight", "Cyan Light"),
-                new LauncherTheme("com.atlauncher.themes.HighTechDarkness", "High Tech Darkness"),
-                new LauncherTheme("com.atlauncher.themes.OneDark", "One Dark")
-            );
+                    new LauncherTheme("com.atlauncher.themes.Dark", "ATLauncher Dark (default)"),
+                    new LauncherTheme("com.atlauncher.themes.Light", "ATLauncher Light"),
+                    new LauncherTheme("com.atlauncher.themes.MonokaiPro", "Monokai Pro"),
+                    new LauncherTheme("com.atlauncher.themes.DraculaContrast", "Dracula Contrast"),
+                    new LauncherTheme("com.atlauncher.themes.HiberbeeDark", "Hiberbee Dark"),
+                    new LauncherTheme("com.atlauncher.themes.Vuesion", "Vuesion"),
+                    new LauncherTheme("com.atlauncher.themes.MaterialPalenightContrast", "Material Palenight Contrast"),
+                    new LauncherTheme("com.atlauncher.themes.ArcOrange", "Arc Orange"),
+                    new LauncherTheme("com.atlauncher.themes.CyanLight", "Cyan Light"),
+                    new LauncherTheme("com.atlauncher.themes.HighTechDarkness", "High Tech Darkness"),
+                    new LauncherTheme("com.atlauncher.themes.OneDark", "One Dark"));
         return themes;
     }
 
@@ -184,7 +182,8 @@ public class GeneralSettingsViewModel implements SettingsListener {
      * @param theme Theme id as provided in {@link LauncherTheme}
      */
     public void setSelectedTheme(String theme) {
-        if (App.settings.theme.equals(theme)) return;
+        if (App.settings.theme.equals(theme))
+            return;
         Analytics.trackEvent(AnalyticsEvent.forThemeChange(App.THEME.getName()));
         App.settings.theme = theme;
         SettingsManager.post();
@@ -233,7 +232,8 @@ public class GeneralSettingsViewModel implements SettingsListener {
      * @param format date format
      */
     public void setDateFormat(String format) {
-        if (App.settings.dateFormat.equals(format)) return;
+        if (App.settings.dateFormat.equals(format))
+            return;
         App.settings.dateFormat = format;
         SettingsManager.post();
     }
@@ -260,7 +260,8 @@ public class GeneralSettingsViewModel implements SettingsListener {
      * @param format instance title format
      */
     public void setInstanceTitleFormat(String format) {
-        if (App.settings.instanceTitleFormat.equals(format)) return;
+        if (App.settings.instanceTitleFormat.equals(format))
+            return;
         App.settings.instanceTitleFormat = format;
         SettingsManager.post();
     }
@@ -294,6 +295,23 @@ public class GeneralSettingsViewModel implements SettingsListener {
     public void setSelectedTabOnStartup(int tab) {
         App.settings.selectedTabOnStartup = tab;
         SettingsManager.post();
+    }
+
+    /**
+     * Set the new design layout
+     *
+     * @param enabled true or false
+     */
+    public void setNewDesignLayout(boolean enabled) {
+        App.settings.enableNewDesginLayout = enabled;
+        SettingsManager.post();
+    }
+
+    /**
+     * Listen to new design layout being enabled
+     */
+    public Observable<Boolean> getNewDesignLayout() {
+        return _newDesignLayout.observeOn(SwingSchedulers.edt());
     }
 
     /**
@@ -375,7 +393,8 @@ public class GeneralSettingsViewModel implements SettingsListener {
      * @param b keep launcher open or not
      */
     public void setKeepLauncherOpen(boolean b) {
-        if (App.settings.keepLauncherOpen == b) return;
+        if (App.settings.keepLauncherOpen == b)
+            return;
         App.settings.keepLauncherOpen = b;
         SettingsManager.post();
     }
@@ -393,7 +412,8 @@ public class GeneralSettingsViewModel implements SettingsListener {
      * @param b console enabled?
      */
     public void setEnableConsole(boolean b) {
-        if (App.settings.enableConsole == b) return;
+        if (App.settings.enableConsole == b)
+            return;
         App.settings.enableConsole = b;
         SettingsManager.post();
     }
@@ -404,7 +424,8 @@ public class GeneralSettingsViewModel implements SettingsListener {
      * @param b enabled?
      */
     public void setEnableTrayMenuOpen(boolean b) {
-        if (App.settings.enableTrayMenu == b) return;
+        if (App.settings.enableTrayMenu == b)
+            return;
         App.settings.enableTrayMenu = b;
         SettingsManager.post();
     }
@@ -421,7 +442,8 @@ public class GeneralSettingsViewModel implements SettingsListener {
     }
 
     public void setEnableDiscordIntegration(boolean b) {
-        if (App.settings.enableDiscordIntegration == b) return;
+        if (App.settings.enableDiscordIntegration == b)
+            return;
         App.settings.enableDiscordIntegration = b;
         SettingsManager.post();
     }
@@ -444,11 +466,11 @@ public class GeneralSettingsViewModel implements SettingsListener {
     }
 
     public void setEnableFeralGameMode(boolean b) {
-        if (App.settings.enableFeralGamemode == b) return;
+        if (App.settings.enableFeralGamemode == b)
+            return;
         App.settings.enableFeralGamemode = b;
         SettingsManager.post();
     }
-
 
     public Observable<Boolean> getDisableCustomFonts() {
         return _disableCustomFonts.observeOn(SwingSchedulers.edt());
@@ -458,7 +480,6 @@ public class GeneralSettingsViewModel implements SettingsListener {
         App.settings.disableCustomFonts = b;
         SettingsManager.post();
     }
-
 
     public void setRememberWindowStuff(boolean remember) {
         App.settings.rememberWindowSizePosition = remember;
@@ -484,7 +505,6 @@ public class GeneralSettingsViewModel implements SettingsListener {
         return _useNativeFilePicker.observeOn(SwingSchedulers.edt());
     }
 
-
     public void setUseNativeFilePicker(boolean b) {
         App.settings.useNativeFilePicker = b;
         SettingsManager.post();
@@ -495,11 +515,11 @@ public class GeneralSettingsViewModel implements SettingsListener {
     }
 
     public void setUseRecycleBin(boolean b) {
-        if (App.settings.useRecycleBin == b) return;
+        if (App.settings.useRecycleBin == b)
+            return;
         App.settings.useRecycleBin = b;
         SettingsManager.post();
     }
-
 
     public boolean showArmSupport() {
         return ConfigManager.getConfigItem("useLwjglReplacement", false);

--- a/src/main/java/com/atlauncher/viewmodel/impl/settings/GeneralSettingsViewModel.java
+++ b/src/main/java/com/atlauncher/viewmodel/impl/settings/GeneralSettingsViewModel.java
@@ -59,7 +59,8 @@ public class GeneralSettingsViewModel implements SettingsListener {
             _dateFormat = BehaviorSubject.create(),
             _addOnInstanceFormat = BehaviorSubject.create(),
             _addOnSelectedTabOnStartup = BehaviorSubject.create(),
-            _addInstanceSorting = BehaviorSubject.create();
+            _addInstanceSorting = BehaviorSubject.create(),
+            _designLayout = BehaviorSubject.create();
 
     private final BehaviorSubject<String> _addOnCustomsDownloadPath = BehaviorSubject.create();
 
@@ -73,8 +74,7 @@ public class GeneralSettingsViewModel implements SettingsListener {
             _useNativeFilePicker = BehaviorSubject.create(),
             _useRecycleBin = BehaviorSubject.create(),
             enableArmSupport = BehaviorSubject.create(),
-            scanModsOnLaunch = BehaviorSubject.create(),
-            _newDesignLayout = BehaviorSubject.create();
+            scanModsOnLaunch = BehaviorSubject.create();
 
     private List<LauncherTheme> themes = null;
 
@@ -104,7 +104,7 @@ public class GeneralSettingsViewModel implements SettingsListener {
         _rememberWindowSizePosition.onNext(App.settings.rememberWindowSizePosition);
         _useNativeFilePicker.onNext(App.settings.useNativeFilePicker);
         _useRecycleBin.onNext(App.settings.useRecycleBin);
-        _newDesignLayout.onNext(App.settings.enableNewDesginLayout);
+        _designLayout.onNext(App.settings.selectDesignLayout);
     }
 
     /**
@@ -302,16 +302,16 @@ public class GeneralSettingsViewModel implements SettingsListener {
      *
      * @param enabled true or false
      */
-    public void setNewDesignLayout(boolean enabled) {
-        App.settings.enableNewDesginLayout = enabled;
+    public void setDesignLayout(int layout) {
+        App.settings.selectDesignLayout = layout;
         SettingsManager.post();
     }
 
     /**
      * Listen to new design layout being enabled
      */
-    public Observable<Boolean> getNewDesignLayout() {
-        return _newDesignLayout.observeOn(SwingSchedulers.edt());
+    public Observable<Integer> getDesignLayout() {
+        return _designLayout.observeOn(SwingSchedulers.edt());
     }
 
     /**

--- a/src/main/java/com/atlauncher/viewmodel/impl/settings/LoggingSettingsViewModel.java
+++ b/src/main/java/com/atlauncher/viewmodel/impl/settings/LoggingSettingsViewModel.java
@@ -28,16 +28,12 @@ import io.reactivex.rxjava3.subjects.BehaviorSubject;
 
 /**
  * @since 2022 / 06 / 17
- * <p>
- * View model for {@link LoggingSettingsTab}
+ *        <p>
+ *        View model for {@link LoggingSettingsTab}
  */
 public class LoggingSettingsViewModel implements SettingsListener {
-    private final BehaviorSubject<String>
-        _forgeLoggingLevel = BehaviorSubject.create();
-
-    private final BehaviorSubject<Boolean>
-        _enableLogging = BehaviorSubject.create(),
-        _enableAnalytics = BehaviorSubject.create();
+    private final BehaviorSubject<Boolean> _enableLogging = BehaviorSubject.create(),
+            _enableAnalytics = BehaviorSubject.create();
 
     public LoggingSettingsViewModel() {
         onSettingsSaved();
@@ -46,19 +42,8 @@ public class LoggingSettingsViewModel implements SettingsListener {
 
     @Override
     public void onSettingsSaved() {
-        _forgeLoggingLevel.onNext(App.settings.forgeLoggingLevel);
         _enableLogging.onNext(App.settings.enableLogs);
         _enableAnalytics.onNext(App.settings.enableAnalytics);
-    }
-
-    public void setLoggingLevel(String level) {
-        if (App.settings.forgeLoggingLevel.equals(level)) return;
-        App.settings.forgeLoggingLevel = level;
-        SettingsManager.post();
-    }
-
-    public Observable<String> getForgeLoggingLevel() {
-        return _forgeLoggingLevel.observeOn(SwingSchedulers.edt());
     }
 
     public Observable<Boolean> getEnableLogging() {


### PR DESCRIPTION
<div align="center">

# UI Revamped
</div>

# Description of the Change
## UI changes
* i changed the old boring instances/server Tabs to Chip/Card/Grid Form
* Reorder the buttons to more compact form
  * Modding dropdown button contains 
    * Add Mods
    * Edit Mods 
  * Backup and Export options moved to dropdown in the settings button
  * The Edit Instance button remains unchanged.
  * The Play button remains unchanged.
  * A new Other Options button in the top-right corner contains:
    *  Open folder
    * Open resources
    * Update
    * Servers
    * Open website
* Updated the top panel items(server tab only for now):
  * Slight adjustment: the search bar and sort options are now on the left side for a more convenient placement.
  * ~~The Import button has been moved to the right side.~~
## ~~graphics/images changes~~
~~* The default Instance/Server image has been updated.~~
~~* The splash image has been updated.~~
## development changes
* i refactor and deleted some chunks of dead code
* Changed how Instance/Server images are rendered. The preferred aspect ratio is now 1:1 to fit the new design; any other aspect ratio will be cropped to maintain the shape.
*Tweaked how the splash image is rendered.

## something to mention
Some UI elements, like the "Modding" button, don't support other language translations because I couldn't access the language resources

## Showcase
### Instances Tab
![image](https://github.com/user-attachments/assets/360f1ac6-07d4-4b39-b983-4077a276a14f)

<details>
<summary>OLD</summary>

![image](https://github.com/user-attachments/assets/1cddd4ca-6bc0-4d1c-99a4-961922e86081)
</details>

### Servers Tab

![image](https://github.com/user-attachments/assets/ad9158a5-2cf4-4784-bcaa-999bad05c745)


## Important 
added dropdown menu to choose the design layout 
![image](https://github.com/user-attachments/assets/58685e4a-d4ef-46c8-9a2d-474b8f182f34)


## Testing
not yet

### Related Issues
not yet
