### PR TITLE
fix: specify StartupWMClass in Linux desktop entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,4 +9,6 @@ This changelog only contains the changes that are unreleased. For changes for in
 
 ### Fixes
 
+- Different app name and desktop entry name when running on Linux.
+
 ### Misc

--- a/packaging/aur/atlauncher-bin/atlauncher.desktop
+++ b/packaging/aur/atlauncher-bin/atlauncher.desktop
@@ -1,5 +1,6 @@
 [Desktop Entry]
 Name=ATLauncher
+StartupWMClass=com-atlauncher-App
 GenericName=ATLauncher
 Comment=A launcher for Minecraft which integrates multiple different modpacks to allow you to download and install modpacks easily and quickly.
 Exec=atlauncher

--- a/packaging/aur/atlauncher/atlauncher.desktop
+++ b/packaging/aur/atlauncher/atlauncher.desktop
@@ -1,5 +1,6 @@
 [Desktop Entry]
 Name=ATLauncher
+StartupWMClass=com-atlauncher-App
 GenericName=ATLauncher
 Comment=A launcher for Minecraft which integrates multiple different modpacks to allow you to download and install modpacks easily and quickly.
 Exec=atlauncher

--- a/packaging/linux/_common/atlauncher.desktop
+++ b/packaging/linux/_common/atlauncher.desktop
@@ -5,6 +5,7 @@ Icon=atlauncher
 Keywords=game;Minecraft;
 MimeType=
 Name=ATLauncher
+StartupWMClass=com-atlauncher-App
 Comment=A launcher for Minecraft which integrates multiple different modpacks to allow you to download and install modpacks easily and quickly.
 Path=
 StartupNotify=true


### PR DESCRIPTION
I've opted not to open an issue or discuss this pull request before opening it because it is a fix and it is quite small. Furthermore, if you don't like it you can just close it, I'll understand.

### Description of the Change

<!-- Give us a description about this Pull Request. The more information you include the better -->

The app window title in the Gnome shell is named `com-atlauncher-App` which doesn't correspond to the `Name` key in the desktop entries, causing a new opaque icon to appear in the dash. Specifying the `StartupWMClass` solves this.

Before:

<img width="238" height="175" alt="Screenshot From 2025-07-20 13-44-52" src="https://github.com/user-attachments/assets/0ed06d50-5390-48dd-933d-3911defbab3e" />

After:

<img width="120" height="154" alt="image" src="https://github.com/user-attachments/assets/cd92c3d9-8616-4c5b-a0a4-a176ebcff6ac" />


### Testing

I've tested it in Gnome 48.

