### PR TITLE
fix: [#1038] MacOS shortcuts doesn't work inside some typing fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This changelog only contains the changes that are unreleased. For changes for in
 - Issues with Legacy Fabric not installing/running [#1029]
 - Attempt to fix unpacking certain zips [#1024]
 - Fixed adding plugins to Paper/Purpur servers via the "Add Mod" button and drag-and-drop in the Edit Mods dialog [#1017]
+- Fixed MacOS issue with shortcuts inside typing fields [#1038]
 
 ### Misc
 None

--- a/src/main/java/com/atlauncher/listener/StatefulTextKeyAdapter.java
+++ b/src/main/java/com/atlauncher/listener/StatefulTextKeyAdapter.java
@@ -82,7 +82,7 @@ public class StatefulTextKeyAdapter extends KeyAdapter {
 
     /**
      * Used as per the empty constructor.
-     * 
+     *
      * @param consumer Consumer to receive events with.
      */
     public void setConsumer(@Nullable Consumer<KeyEvent> consumer) {
@@ -97,13 +97,16 @@ public class StatefulTextKeyAdapter extends KeyAdapter {
         // Ignore if it is a shift key (for shift selection)
         // Ignore if it is a control key (for ctrl commands)
         // Ignore if it is an alt key
+        // Ignore if it is a MacBook CMD key
         // Ignore if the modifiers has control down (for ctrl commands)
+        // Ignore if the modifiers has command down (for cmd commands)
         if (e != null &&
                 !e.isActionKey() &&
                 e.getKeyCode() != KeyEvent.VK_SHIFT &&
                 e.getKeyCode() != KeyEvent.VK_CONTROL &&
                 e.getKeyCode() != KeyEvent.VK_ALT &&
-                e.getModifiersEx() != KeyEvent.CTRL_DOWN_MASK && consumer != null) {
+                e.getModifiersEx() != KeyEvent.CTRL_DOWN_MASK &&
+                e.getModifiersEx() != KeyEvent.META_DOWN_MASK && consumer != null) {
             consumer.accept(e);
         } else {
             if (ignoredReceiver != null) {

--- a/src/main/java/com/atlauncher/listener/StatefulTextKeyAdapter.java
+++ b/src/main/java/com/atlauncher/listener/StatefulTextKeyAdapter.java
@@ -105,6 +105,7 @@ public class StatefulTextKeyAdapter extends KeyAdapter {
                 e.getKeyCode() != KeyEvent.VK_SHIFT &&
                 e.getKeyCode() != KeyEvent.VK_CONTROL &&
                 e.getKeyCode() != KeyEvent.VK_ALT &&
+                e.getKeyCode() != KeyEvent.VK_META &&
                 e.getModifiersEx() != KeyEvent.CTRL_DOWN_MASK &&
                 e.getModifiersEx() != KeyEvent.META_DOWN_MASK && consumer != null) {
             consumer.accept(e);


### PR DESCRIPTION
### Description of the Change

Added a check for VK_META and META_DOWN_MASK key events to StatefulTextKeyAdapter class for catching MacOS CMD key as alternative to Windows/Linux Ctrl key for shortcuts.